### PR TITLE
Handle number of keys other than 4

### DIFF
--- a/spacemouse-keys/calibration.cpp
+++ b/spacemouse-keys/calibration.cpp
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include "calibration.h"
+#include "config.h"
 
 void printArray(int arr[], int size) {
   /*This functions prints an array to the Serial and you can copy the output the c code again.
@@ -22,7 +23,6 @@ void printArray(int arr[], int size) {
 }
 
 char *axisNames[] = {"AX:", "AY:", "BX:", "BY:", "CX:", "CY:", "DX:", "DY:"}; // 8
-char *keyNames[] = {"K0:", "K1:", "K2:", "K3:"}; // 4
 char *velNames[] = {"TX:", "TY:", "TZ:", "RX:", "RY:", "RZ:"}; // 6
 
 void debugOutput1(int* rawReads, int* keyVals) {
@@ -32,8 +32,10 @@ void debugOutput1(int* rawReads, int* keyVals) {
     Serial.print(rawReads[i]);
     Serial.print(", ");
   }
-  for (int i = 0; i < 4; i++) {
-    Serial.print(keyNames[i]);
+  for (int i = 0; i < NUMKEYS; i++) {
+    Serial.print("K");
+    Serial.print(i);
+    Serial.print(":");
     Serial.print(keyVals[i]);
     Serial.print(", ");
   }
@@ -57,9 +59,11 @@ void debugOutput4(int16_t* velocity, int8_t* keyOut) {
     Serial.print(velocity[i]);
     Serial.print(", ");
   }
-  for (int i = 0; i < 4; i++) {
-    Serial.print(keyNames[i]);
-    Serial.print(keyOut[i]);
+  for (int i = 0; i < NUMKEYS; i++) {
+    Serial.print("K");
+    Serial.print(i);
+    Serial.print(":");
+    Serial.print(keyVals[i]);
     Serial.print(", ");
   }
   Serial.println("");

--- a/spacemouse-keys/spacemouse-keys.ino
+++ b/spacemouse-keys/spacemouse-keys.ino
@@ -81,7 +81,7 @@ int centerPoints[8];
 // Variables to read of the keys
 int keyVals[NUMKEYS]; //store raw value of the keys, without debouncing
 //Needed for key evaluation
-int8_t keyOut[NUMKEYS];
+uint8_t keyOut[NUMKEYS];
 int8_t key_waspressed[NUMKEYS];
 unsigned long timestamp[NUMKEYS];
 
@@ -147,22 +147,22 @@ void setup() {
   Serial.setTimeout(2); // the serial interface will look for new debug values and it will only wait 2ms
   // Read idle/centre positions for joysticks.
   readAllFromJoystick(centerPoints);
-  readAllFromJoystick(centerPoints);
   delay(100);
   Serial.println("Please enter the debug mode now or while the script is reporting. -1 to shut off.");
 }
 
 // Function to send translation and rotation data to the 3DConnexion software using the HID protocol outlined earlier. Two sets of data are sent: translation and then rotation.
 // For each, a 16bit integer is split into two using bit shifting. The first is mangitude and the second is direction.
-void send_command(int16_t rx, int16_t ry, int16_t rz, int16_t x, int16_t y, int16_t z, int8_t k1, int8_t k2, int8_t k3, int8_t k4) {
+void send_command(int16_t rx, int16_t ry, int16_t rz, int16_t x, int16_t y, int16_t z, uint8_t *keys) {
   uint8_t trans[6] = { x & 0xFF, x >> 8, y & 0xFF, y >> 8, z & 0xFF, z >> 8 };
   HID().SendReport(1, trans, 6);
   uint8_t rot[6] = { rx & 0xFF, rx >> 8, ry & 0xFF, ry >> 8, rz & 0xFF, rz >> 8 };
   HID().SendReport(2, rot, 6);
 
-  // LivingTheDream added
-  uint8_t key[NUMKEYS] = {k1, k2, k3, k4};
-  HID().SendReport(3, key, 4);
+  if (NUMKEYS > 0) {
+    // LivingTheDream added
+    HID().SendReport(3, keys, NUMKEYS);
+  }
 }
 
 int rawReads[8], centered[8];
@@ -326,9 +326,9 @@ void loop() {
   // The correct order for TeachingTech was determined after trial and error
 #if SWITCHYZ > 0
   //Original from TT, but 3DConnextion tutorial will not work:
-  send_command(velocity[ROTX], velocity[ROTZ], velocity[ROTY], velocity[TRANSX], velocity[TRANSZ], velocity[TRANSY], keyOut[0], keyOut[1], keyOut[2], keyOut[3]);
+  send_command(velocity[ROTX], velocity[ROTZ], velocity[ROTY], velocity[TRANSX], velocity[TRANSZ], velocity[TRANSY], keyOut);
 #else
   // Daniel_1284580 noticed the 3dconnexion tutorial was not working the right way so they got changed
-  send_command(velocity[ROTX], velocity[ROTY], velocity[ROTZ], velocity[TRANSX], velocity[TRANSY], velocity[TRANSZ], keyOut[0], keyOut[1], keyOut[2], keyOut[3]);
+  send_command(velocity[ROTX], velocity[ROTY], velocity[ROTZ], velocity[TRANSX], velocity[TRANSY], velocity[TRANSZ], keyOut);
 #endif
 }


### PR DESCRIPTION
There were still some places where the number of keys was hardcoded to 4. I updated the calibration debug output and the send_command to handle any number of keys. (Numbers other than 0 or 4 might not actually be useful, depending on how the 3DConnexion software handles it.

I'm still finishing up my space mouse build and also am not building it with keys, so I'm marking this as draft until I've been able to test it better.