### PR TITLE
Implemented kill-keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,43 +18,109 @@ Wanted, with unclear solution ... ?
 - [ ] Reverse Direction and Speed options in 3dConnexion Software is not working, because our spacemouse is not accepting this settings.
 
 # Getting Started
-This is a short overview, what needs to be done to get this project running. The paragraphs below will be extended in the future with links or further text.
+1. You purchase the [electronics](#electronics) and [print some parts](#printed-parts), which is not scope of this repository
+2. [Create a custom board](#custom-board-to-emulate-the-space-mouse) in your Arduino IDE, that emulates the original space mouse
+3. [Download or clone this github repository](#cloning-the-github-repo)
+4. [Rename the config_sample.h to config.h](#create-your-own-config-file)
+5. [Try to compile and flash your board](#compiling-and-flashing-the-firmware)
+6. [Assign the pins of the joysticks and go through the calibration](#calibrate-your-hardware)
+7. [Use your space mouse](#use-the-spacemouse)
 
-## Spacemouse emulation
-*Check the [TeachingTech](https://www.printables.com/de/model/864950-open-source-spacemouse-space-mushroom-remix) video for proper instructions until more usefull stuff is written here...*
+## Custom board to emulate the space mouse
+The boards.txt file needs an additional Board definition, which tells the processor to report the USB identifiers correctly and immitate the 3dconnexion space-mouse.
 
-Teaching Tech followed the instructions here from nebhead: https://gist.github.com/nebhead/c92da8f1a8b476f7c36c032a0ac2592a
-with two key differences:
-
-1. Teaching Tech changed the word 'DaemonBite' to 'Spacemouse' in all references.
-2. Teaching Tech changed the VID and PID values as per jfedor's instructions: vid=0x256f, pid=0xc631 (SpaceMouse Pro Wireless (cabled))
-
-Daniel_1284580 recomments changing leonardo.upload.tool=avrdude to leonardo.upload.tool.serial=avrdude to get no error when compiling
-
-When compiling and uploading, Teaching Tech select Arduino AVR boards (in Sketchbook) > Spacemouse and then the serial port.
-
-If you have the problem, that the port can not be found, the bootloader of your board is probably not reachable. The problem is, that the arduino pro micro has a very short time to get into the bootloader of 800 ms.
-Therefore you need to connect the reset pin twice to gnd. Than you have 8s to initially set the com port and upload your sketch. It is also quite a fast timing and needs some number of tries. Make sure to select the proper 5V 16MHz (if you also have this board). You can read the details for this reset here: https://learn.sparkfun.com/tutorials/pro-micro--fio-v3-hookup-guide/troubleshooting-and-faq#ts-reset
-
-You will also need to download and install the 3DConnexion software: https://3dconnexion.com/us/drivers-application/3dxware-10/
-If all goes well, the 3DConnexion software will show a SpaceMouse Pro wireless when the Arduino is connected.
+### Boards.txt on linux
+You find the boards.txt in ```~/.arduino15/packages/SparkFun/hardware/avr/1.1.13```.
+If this folder doesn't exist you need to install board support for SparkFun Arduinos.
 
 ### boards.txt on mac
-https://gist.github.com/maunsen/8dbee2bddef027b04a450241c7d36668
+Please read https://gist.github.com/maunsen/8dbee2bddef027b04a450241c7d36668
+
+### boards.txt on windows
+C:\Users<USER>\AppData\Local\Arduino15\packages\arduino\hardware
+
+### Code to add to boards.txt
+Here is the addition, which needs to be copied into the boards.txt (e.g. at the bottom). 
+```
+# Add this to the bottom your boards.txt
+
+################################################################################
+################################## Spacemouse based on Pro Micro ###################################
+################################################################################
+spacemouse.name=SpaceMouse
+
+spacemouse.upload.tool=avrdude
+spacemouse.upload.protocol=avr109
+spacemouse.upload.maximum_size=28672
+spacemouse.upload.maximum_data_size=2560
+spacemouse.upload.speed=57600
+spacemouse.upload.disable_flushing=true
+spacemouse.upload.use_1200bps_touch=true
+spacemouse.upload.wait_for_upload_port=true
+
+spacemouse.bootloader.tool=avrdude
+spacemouse.bootloader.unlock_bits=0x3F
+spacemouse.bootloader.lock_bits=0x2F
+spacemouse.bootloader.low_fuses=0xFF
+spacemouse.bootloader.high_fuses=0xD8
+
+spacemouse.build.board=AVR_PROMICRO
+spacemouse.build.core=arduino:arduino
+spacemouse.build.variant=promicro
+spacemouse.build.mcu=atmega32u4
+spacemouse.build.usb_product="Spacemouse Pro Wireless (cabled)"
+spacemouse.build.usb_manufacturer="3Dconnexion"
+spacemouse.build.vid=0x256f
+spacemouse.build.extra_flags={build.usb_flags}
+
+############################# Spacemouse Pro Micro 5V / 16MHz #############################
+# deleted 3.3V / 8 Mhz variant to avoid bricking
+
+spacemouse.build.pid.0=0xc631
+spacemouse.build.pid.1=0xc631
+spacemouse.build.pid=0xc631
+spacemouse.build.f_cpu=16000000L
+
+spacemouse.bootloader.extended_fuses=0xCB
+spacemouse.bootloader.file=caterina/Caterina-promicro16.hex
+```
+
+
+### Further reading / FAQ regarding the boards.txt:
+
+- [TeachingTech](https://www.printables.com/de/model/864950-open-source-spacemouse-space-mushroom-remix) video for proper instructions
+- Teaching Tech followed the instructions here from [nebhead](https://gist.github.com/nebhead/c92da8f1a8b476f7c36c032a0ac2592a) with two key differences:
+	- Changed the word 'DaemonBite' to 'Spacemouse' in all references.
+  	- Changed the VID and PID values as per jfedor's instructions: vid=0x256f, pid=0xc631 (SpaceMouse Pro Wireless (cabled))
+-  Some [people](https://gist.github.com/nebhead/c92da8f1a8b476f7c36c032a0ac2592a?permalink_comment_id=5069434#gistcomment-5069434) need to change ```spacemouse.upload.tool=avrdude``` to ```spacemouse.upload.tool.serial=avrdude``` to get no error when compiling
 
 ## Cloning the github repo
-Clone the github repo to your computer (or download it).
+Clone the github repo to your computer: Scroll-Up to the green "<> Code" Button and select, if you wish to clone or just download the code.
 
 ## Create your own config file
 Copy the config_sample.h and rename it to config.h.
-Open the Arduino IDE, select the board and try to compile the project.
+This is done to avoid the personal config file being overwritten when pulling new updates from this repository. You probably have to update the config.h file with new additions from the config_sample.h, but your pin assignment will not stay.
+
+## Compiling and flashing the firmware
+- Open the Arduino IDE (1.8.19 and 2.3.2 are tested on Ubuntu).
+- Open spacemouse-keys.ino
+- Select Tools -> Board -> SparkFun AVR Boards -> Spacemouse.
+- (If you followed another boards.txt instructions, which also allow 3.3V with 8 Mhz: Make sure to select the proper processor: 5V 16MHz)  
+- Select the correct port (see troubleshooting section, which might be necessary for first upload)
+- Compile the firmware
+
+### Troubleshooting uploading
+If you have the problem, that the port can not be found, the bootloader of your board is probably not reachable. The problem is, that the arduino pro micro has a very short time to get into the bootloader of 800 ms.
+Therefore you need to connect the reset pin twice to gnd. Than you have 8 s to initially set the com port and upload your sketch. It is also quite a fast timing and needs some number of tries. 
+
+You can read the details for this reset here: https://learn.sparkfun.com/tutorials/pro-micro--fio-v3-hookup-guide/troubleshooting-and-faq#ts-reset
 
 ## Calibrate your hardware 
 After compiling and uploading the programm to your hardware, you can connect via the serial monitor. In the upper line, you can send the desired debug mode to the board and observe the output. "-1" stops the debug output.
 
 Read and follow the instructions throughout the config.h file and write down your results. Recompile after every step.
 
-1. Check and correct your pin out
+1. Check and correct your pin out -> Refer to the pictures in the (Electronics)[#electronics] section below.
 2. Tune dead zone to avoid jittering
 3. Getting min and max values for your joysticks 
 	- There is a semi-automatic approach, which returns you the minimum and maximum values seen within 15s.
@@ -62,6 +128,13 @@ Read and follow the instructions throughout the config.h file and write down you
 
 This calibration is supported by various debug outputs which can toggle on or off before compiling or during run time by sending the corresponding number via the serial interface.
 
+## Use the spacemouse
+### Download the 3dconnexion driver on windows and mac
+You will also need to download and install the 3DConnexion software: https://3dconnexion.com/us/drivers-application/3dxware-10/
+If all goes well, the 3DConnexion software will show a SpaceMouse Pro wireless when the Arduino is connected.
+
+### spacenav for linux users
+Checkout https://wiki.freecad.org/3Dconnexion_input_devices and https://github.com/FreeSpacenav/spacenavd.
 
 # Software Main Idea 
 1. The software reads the eight ADC values of the four joy sticks

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Repository for the space mouse based on four joysticks with an addition for keys
 This repository for the necessary arduino sources is mainly based on 
 the work by [TeachingTech](https://www.printables.com/de/model/864950-open-source-spacemouse-space-mushroom-remix) and the additional code for keys by [LivingTheDream](https://www.printables.com/de/model/883967-tt-spacemouse-v2-lid-with-mounting-for-4-mx-switch) and is intended as basis for further development, because proper source code management is needed.
 
+## Additional Features
+- [x] Semi-Automatic calibration methods
+- [x] Support for keys, that can triggger functions on your pc
+- [x] Support for "kill-keys", that disable translation or rotation directly in the mouse
+
+Coming up:
+- [ ] Support for wheel to zoom (merging from [JoseLuizGZA](https://github.com/JoseLuisGZA/ErgonoMouse/)) 
+
 # Getting Started
 This is a short overview, what needs to be done to get this project running. The paragraphs below will be extended in the future with links or further text.
 
@@ -54,6 +62,8 @@ This calibration is supported by various debug outputs which can toggle on or of
 4. The movement of the joysticks is mapped from the original about ca. +/- 500 digits to exactly +/- 350. (Therefore the real min and max values will be calibrated) Now all further calculations can be done with this normalized values between +/-350.
 5. We calculate the translation and rotation based on this.
 6. Applying the modifiers to minimize very small rotations or translations.
+7. Kill, swap or invert movements
+8. Sending the velocities and keys to the PC
 
 # Printed parts
 * https://www.printables.com/de/model/864950-open-source-spacemouse-space-mushroom-remix
@@ -90,6 +100,8 @@ The basis is fdmakara's four joystick movement logic, with jfedor/BennyBWalker's
 9. Improved code to make it more userfriendly by Daniel_1284580 (In Software Version V2 and newer)
 10. Improved Code, improved comments and added written tutorials in comments, By LivingTheDream: https://www.printables.com/de/model/883967-tt-spacemouse-v2-lid-with-mounting-for-4-mx-switch/files Implemented new algorithm "modifier function" for better motioncontrol by Daniel_1284580 (In Software Version V3) 
 11. Moved the Deadzone detection into the inital ADC conversion and calculate every value everytime and use the modifier for better seperation between the access, By Andun_HH.
+12. Added two additional buttons integrated into the knob to kill either translation or rotation at will and prevent unintended movements, by JoseLuisGZA.
+13. Coming up: Added Encoder to use with a wheel on top of the main knob an simulate pulls on any of the axis (main use is simulating zoom like the mouse wheel), by [JoseLuizGZA](https://github.com/JoseLuisGZA/ErgonoMouse/).
 
 # License
 Because TeachingTech published his source code on Printables under this license, it also applies here:

--- a/spacemouse-keys/calibration.cpp
+++ b/spacemouse-keys/calibration.cpp
@@ -20,8 +20,8 @@ void printArray(int arr[], int size) {
   Serial.println("}");
 }
 
-char *axisNames[] = {"AX:", "AY:", "BX:", "BY:", "CX:", "CY:", "DX:", "DY:"}; // 8
-char *velNames[] = {"TX:", "TY:", "TZ:", "RX:", "RY:", "RZ:"}; // 6
+char* axisNames[] = { "AX:", "AY:", "BX:", "BY:", "CX:", "CY:", "DX:", "DY:" };  // 8
+char* velNames[] = { "TX:", "TY:", "TZ:", "RX:", "RY:", "RZ:" };                 // 6
 
 void debugOutput1(int* rawReads, int* keyVals) {
   // Report back 0-1023 raw ADC 10-bit values if enabled
@@ -84,10 +84,10 @@ void debugOutput5(int* centered, int16_t* velocity) {
 }
 
 // Variables and function to get the min and maximum value of the centered values
-int minMaxCalcState = 0; // little state machine -> setup in 0 -> measure in 1 -> output in 2 ->  end in 3
-int minValue[8]; // Array to store the minimum values
-int maxValue[8]; // Array to store the maximum values
-unsigned long startTime; // Start time for the measurement
+int minMaxCalcState = 0;  // little state machine -> setup in 0 -> measure in 1 -> output in 2 ->  end in 3
+int minValue[8];          // Array to store the minimum values
+int maxValue[8];          // Array to store the maximum values
+unsigned long startTime;  // Start time for the measurement
 
 void calcMinMax(int* centered) {
   // compile the sketch, upload it and wait for confirmation in the serial console.
@@ -98,14 +98,13 @@ void calcMinMax(int* centered) {
     delay(2000);
     // Initialize the arrays
     for (int i = 0; i < 8; i++) {
-      minValue[i] = 1023; // Set the min value to the maximum possible value
-      maxValue[i] = 0; // Set the max value to the minimum possible value
+      minValue[i] = 1023;  // Set the min value to the maximum possible value
+      maxValue[i] = 0;     // Set the max value to the minimum possible value
     }
-    startTime = millis(); // Record the current time
-    minMaxCalcState = 1; // next State: measure!
+    startTime = millis();  // Record the current time
+    minMaxCalcState = 1;   // next State: measure!
     Serial.println(F("Please start moving the spacemouse around!"));
-  }
-  else if (minMaxCalcState == 1) {
+  } else if (minMaxCalcState == 1) {
     if (millis() - startTime < 15000) {
       for (int i = 0; i < 8; i++) {
         // Update the minimum and maximum values
@@ -116,14 +115,12 @@ void calcMinMax(int* centered) {
           maxValue[i] = centered[i];
         }
       }
-    }
-    else {
+    } else {
       // 15s are over. go to next state and report via console
       Serial.println(F("Stop moving the spacemouse. These are the result:"));
       minMaxCalcState = 2;
     }
-  }
-  else if (minMaxCalcState == 2) {
+  } else if (minMaxCalcState == 2) {
     Serial.print(F("MINVALS "));
     printArray(minValue, 8);
     Serial.print(F("MAXVALS "));
@@ -146,6 +143,6 @@ void calcMinMax(int* centered) {
         Serial.println(maxValue[i]);
       }
     }
-    minMaxCalcState = 3; // no further reporting
+    minMaxCalcState = 3;  // no further reporting
   }
 }

--- a/spacemouse-keys/config_sample.h
+++ b/spacemouse-keys/config_sample.h
@@ -110,23 +110,26 @@
 #define ROTY_SENSITIVITY 1.5
 #define ROTZ_SENSITIVITY 2
 
+// ------------------------------------------------------------------------------------
 // Direction
-// Modify the direction of translation/rotation depending on preference. This can also be done per application in the 3DConnexion software afterwards
+// Modify the direction of translation/rotation depending on preference. 
+// This should be done, when you are done with the pin assignment.
+// The default 0 is here for x, y and z orientation as to the picture in the readem
+// The suggestion in the comments is to accomodate the 3dConnexion Trainer "3Dc"
 // Switch between true/false as desired.
-// Switch between true/false as desired.
-#define INVX 0   // pan left/right
-#define INVY 0   // pan up/down
-#define INVZ 0   // zoom in/out
-#define INVRX 0  // Rotate around X axis (tilt front/back)
-#define INVRY 0  // Rotate around Y axis (tilt left/right)
-#define INVRZ 0  // Rotate around Z axis (twist left/right)
+#define INVX 0   // pan left/right  // 3Dc: 0
+#define INVY 0   // pan up/down     // 3Dc: 1
+#define INVZ 0   // zoom in/out     // 3Dc: 1
+#define INVRX 0  // Rotate around X axis (tilt front/back)  // 3Dc: 0
+#define INVRY 0  // Rotate around Y axis (tilt left/right)  // 3Dc: 1
+#define INVRZ 0  // Rotate around Z axis (twist left/right) // 3Dc: 1
 
 //Switch Zooming with Up/Down Movement
 //DISCLAIMER: This will make your spacemouse work like in the original code from TeachingTech, but if you try the 3DConnexion tutorial in the Spacemouse Home Software you will notice it won't work.
 #define SWITCHYZ 0  //change to true for switching movement
 
-//
-// -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------------
+// Keys Support
 // How many keys are there in total?
 #define NUMKEYS 4
 // Define the pins for the keys

--- a/spacemouse-keys/config_sample.h
+++ b/spacemouse-keys/config_sample.h
@@ -13,7 +13,8 @@
 
 // First step: Wiring. Matches the first eight analogue pins of the Arduino Pro Micro (atmega32u4) to the following axis
 // AX, AY, BX, BY, CX, CY, DX, DY
-#define PINLIST { A1, A0, A3, A2, A7, A6, A9, A8 }
+#define PINLIST \
+  { A1, A0, A3, A2, A7, A6, A9, A8 }
 // Check the correct wiring with the debug output=1
 
 // Debugging (You can send the number over the serial interface, whenever you whish)
@@ -25,6 +26,7 @@
 // 3: Output centered joystick values. Filtered for deadzone. Approx -350 to +350, locked to zero at idle, modified with a function.
 // 4: Output translation and rotation values. Approx -350 to +350 depending on the parameter.
 // 5: Output debug 4 and 5 side by side for direct cause and effect reference.
+// 6: Report velocity and keys after possible kill-key feature
 #define STARTDEBUG 0
 
 // Modifier Function
@@ -40,7 +42,7 @@
 // Second calibration: Tune Deadzone
 // Deadzone to filter out unintended movements. Increase if the mouse has small movements when it should be idle or the mouse is too senstive to subtle movements.
 // Set debug = 2. Don't touch the mouse but observe the values. They should be nearly to zero. Every value around zero which is noise or should be neglected afterwards is in the following deadzone.
-#define DEADZONE 3 // Recommended to have this as small as possible for V2 to allow smaller knob range of motion.
+#define DEADZONE 3  // Recommended to have this as small as possible for V2 to allow smaller knob range of motion.
 
 // Third calibration: getting min and max values
 // Can be done manual (debug = 2) or semi-automatic (debug = 20)
@@ -78,8 +80,8 @@
 // 8. You finished calibrating.
 
 // Insert measured Values like this: {AX,AY,BX,BY,CY,CY,DX,DY}.
-#define MINVALS { -512, -512, -512, -512, -512, -512, -512, -512};
-#define MAXVALS { +512, +512, +512, +512, +512, +512, +512, +512};
+#define MINVALS { -512, -512, -512, -512, -512, -512, -512, -512 };
+#define MAXVALS { +512, +512, +512, +512, +512, +512, +512, +512 };
 
 // Fourth calibration: Sensitivity
 // Independent sensitivity multiplier for each axis movement. Use degbug mode 4 or use for example your cad program to verify changes.
@@ -98,11 +100,11 @@
 #define TRANSX_SENSITIVITY 2
 #define TRANSY_SENSITIVITY 2
 #define POS_TRANSZ_SENSITIVITY 0.5
-#define NEG_TRANSZ_SENSITIVITY 5 //I want low sensitiviy for down, therefore a high value.
-#define GATE_NEG_TRANSZ 15 // gate value, which negative z movements will be ignored (like an additional deadzone for -z).
-#define GATE_ROTX 15 // Value under which rotX values will be forced to zero
-#define GATE_ROTY 15 // Value under which roty values will be forced to zero
-#define GATE_ROTZ 15 // Value under which rotz values will be forced to zero
+#define NEG_TRANSZ_SENSITIVITY 5  //I want low sensitiviy for down, therefore a high value.
+#define GATE_NEG_TRANSZ 15        // gate value, which negative z movements will be ignored (like an additional deadzone for -z).
+#define GATE_ROTX 15              // Value under which rotX values will be forced to zero
+#define GATE_ROTY 15              // Value under which roty values will be forced to zero
+#define GATE_ROTZ 15              // Value under which rotz values will be forced to zero
 
 #define ROTX_SENSITIVITY 1.5
 #define ROTY_SENSITIVITY 1.5
@@ -112,25 +114,65 @@
 // Modify the direction of translation/rotation depending on preference. This can also be done per application in the 3DConnexion software afterwards
 // Switch between true/false as desired.
 // Switch between true/false as desired.
-#define INVX  0 // pan left/right
-#define INVY  0 // pan up/down
-#define INVZ  0 // zoom in/out
-#define INVRX  0 // Rotate around X axis (tilt front/back)
-#define INVRY  0 // Rotate around Y axis (tilt left/right)
-#define INVRZ  0 // Rotate around Z axis (twist left/right)
+#define INVX 0   // pan left/right
+#define INVY 0   // pan up/down
+#define INVZ 0   // zoom in/out
+#define INVRX 0  // Rotate around X axis (tilt front/back)
+#define INVRY 0  // Rotate around Y axis (tilt left/right)
+#define INVRZ 0  // Rotate around Z axis (twist left/right)
 
 //Switch Zooming with Up/Down Movement
 //DISCLAIMER: This will make your spacemouse work like in the original code from TeachingTech, but if you try the 3DConnexion tutorial in the Spacemouse Home Software you will notice it won't work.
-#define SWITCHYZ 0 //change to true for switching movement
+#define SWITCHYZ 0  //change to true for switching movement
 
 //
 // -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-// Define the keycodes for each key
+// How many keys are there in total?
 #define NUMKEYS 4
 // Define the pins for the keys
-#define K0 15
-#define K1 14
-#define K2 16
-#define K3 10
+// the first pins are reported via HID
+#define KEYLIST \
+  { 15, 14, 16, 10 }
+// How many keys reported?
+#define NUMHIDKEYS 2
 
-#define DEBOUNCE_KEYS_MS 200 // time in ms which is needed to allow a new button press
+// Kill-Key Feature: Are there buttons to set the translation or rotation to zero?
+// How many kill keys are there? (disabled: 0; enabled: 2)
+#define NUMKILLKEYS 2
+// usually you take the last two buttons from KEYLIST as kill-keys
+// Index of the kill key for rotation
+#define KILLROT 2
+// Index of the kill key for translation
+#define KILLTRANS 3
+// Note: Technically can report the kill-keys via HID as "usual" buttons, but that doesn't make much sense...
+
+/*  Example for three usual buttons and no kill-keys
+ *  There are three keys in total:  NUMKEYS 3
+ *  The keys which shall be reported to the pc are connected to pin 15, 14 and 16
+ *  KEYLIST {15, 14, 16}
+ *  Therefore, the first three pins from the KEYLIST apply for the HID: NUMHIDKEYS 3
+ *  No keys for kill-keys NUMKILLKEYS 0
+ *  KILLROT and KILLTRANS don't matter... KILLROT 0 and KILLTRANS 0
+*/
+
+/* 
+ *  Example for two usual buttons and two kill-keys:
+ *  There are four keys in total:  NUMKEYS 4
+ *  The keys which shall be reported to the pc are connected to pin 15 and 14
+ *  The keys which shall be used to kill translation or rotation are connected to pin 16 and 10
+ *  KEYLIST {15, 14, 16, 10}
+ *  Therefore, the first two pins from the KEYLIST apply for the HID: NUMHIDKEYS 2
+ *  Two keys are used as kill-keys: NUMKILLKEYS 2
+ *  The first kill key has the third position in the KEYLIST and due to zero-based counting third-1 => KILLROT 2
+ *  The second kill key has the last position in the KEYLIST with index 3 -> KILLTRANS 3
+ */
+
+#if (NUMKILLKEYS > NUMKEYS)
+#error "Number of Kill Keys can not be larger than total number of keys"
+#endif
+#if (NUMKILLKEYS > 0 && ((KILLROT > NUMKEYS) || (KILLTRANS > NUMKEYS)))
+#error "Index of killkeys must be smaller than the total number of keys"
+#endif
+
+
+#define DEBOUNCE_KEYS_MS 200  // time in ms which is needed to allow a new button press

--- a/spacemouse-keys/spaceKeys.cpp
+++ b/spacemouse-keys/spaceKeys.cpp
@@ -1,0 +1,59 @@
+// The user specific settings, like pin mappings or special configuration variables and sensitivities are stored in config.h.
+// Please open config_sample.h, adjust your settings and save it as config.h
+#include "config.h"
+#include <Arduino.h>
+// check config.h if this functions and variables are needed
+#if NUMKEYS > 0
+
+// array with the pin definition of all keys
+int keyList[NUMKEYS] = KEYLIST;
+
+//Needed for key evaluation
+int8_t key_waspressed[NUMKEYS];
+unsigned long timestamp[NUMKEYS];
+
+// Function to setup up all keys in keyList
+void setupKeys() {
+  for (int i = 0; i < NUMKEYS; i++) {
+    pinMode(keyList[i], INPUT_PULLUP);
+  }
+}
+
+
+// Function to read and store the digital states for each of the keys
+void readAllFromKeys(int* keyVals) {
+  for (int i = 0; i < NUMKEYS; i++) {
+    keyVals[i] = digitalRead(keyList[i]);
+  }
+}
+
+// Evaluate and debounce all keys from the raw keyVals into the debounced keyOut.
+// The keyOut is only 1 for one iteration of the loop.
+// If you want to know, if the key is pressed all the time (for the kill-key feature), use the not debounced raw keyVal!
+void evalKeys(int* keyVals, uint8_t* keyOut) {
+  //Button Evaluation
+  for (int i = 0; i < NUMKEYS; i++) {
+    // The keys are configured with pull_up, see setupKeys() and are pulled to ground, when pressed.
+    // Therefore, the pressed key is false, which is an inverted logic
+    if (!keyVals[i]) {  // the key is pressed
+      // Making sure button cannot trigger multiple times which would result in overloading HID.
+      if (key_waspressed[i] == 0) {  // if the button has not been pressed lately:
+        keyOut[i] = 1;               // this is the variable telling the outside world only one iteration, that the key was pressed
+        key_waspressed[i] = 1;       // remember, that we already told the outside world about this key
+        timestamp[i] = millis();     // remember the time, the button was pressed
+        Serial.print("Key: ");       // this is always sent over the serial console, and not only in debug
+        Serial.println(i);
+      } else {  // the button was already pressed and is still pressed (and the event sent in the last loop), don't send the keyOut event again.
+        keyOut[i] = 0;
+      }
+    } else {                         // the button is not pressed
+      if (key_waspressed[i] == 1) {  // has it been pressed lately?
+        // debouncing:
+        if (millis() - timestamp[i] > DEBOUNCE_KEYS_MS) {  // check if the last button press is long enough in the past
+          key_waspressed[i] = 0;                           // reset this marker and allow a new button press
+        }
+      }
+    }
+  }
+}
+#endif

--- a/spacemouse-keys/spaceKeys.h
+++ b/spacemouse-keys/spaceKeys.h
@@ -1,0 +1,6 @@
+// header for spaceKeys.cpp
+// Handle all the keys for the spacemouse
+
+void readAllFromKeys(int* keyVals);
+void setupKeys();
+void evalKeys(int* keyVals, uint8_t* keyOut);

--- a/spacemouse-keys/spacemouse-keys.ino
+++ b/spacemouse-keys/spacemouse-keys.ino
@@ -5,63 +5,68 @@
 // One good starting point is the work and video by TeachingTech: https://www.printables.com/de/model/864950-open-source-spacemouse-space-mushroom-remix
 // Then follow along on github, how we reached this state of the source code.
 
-// Include inbuilt Arduino HID library by NicoHood: https://github.com/NicoHood/HID
-#include "HID.h"
-//Include math operators for doing better calculation algorithms. Arduino math is a standard library already included.
-#include <math.h>
-#define sign(x) ((x) < 0 ? -1 : ((x) > 0 ? 1 : 0)) //Define Signum Function
-
-#include "calibration.h"
-
 // The user specific settings, like pin mappings or special configuration variables and sensitivities are stored in config.h.
 // Please open config_sample.h, adjust your settings and save it as config.h
 #include "config.h"
 
+// Include inbuilt Arduino HID library by NicoHood: https://github.com/NicoHood/HID
+#include "HID.h"
+//Include math operators for doing better calculation algorithms. Arduino math is a standard library already included.
+#include <math.h>
+#define sign(x) ((x) < 0 ? -1 : ((x) > 0 ? 1 : 0))  //Define Signum Function
+
+// header file for calibration output and helper routines
+#include "calibration.h"
+
+// header file for reading the keys
+#include "spaceKeys.h"
+
+// the debug mode can be set during runtime via the serial interface
 int debug = STARTDEBUG;
 
 // This portion sets up the communication with the 3DConnexion software. The communication protocol is created here.
 // hidReportDescriptor webpage can be found here: https://eleccelerator.com/tutorial-about-usb-hid-report-descriptors/
 // Altered physical, logical range to ranges the 3DConnexion software expects by Daniel_1284580.
 static const uint8_t _hidReportDescriptor[] PROGMEM = {
-  0x05, 0x01,           // Usage Page (Generic Desktop)
-  0x09, 0x08,           // Usage (Multi-Axis)
-  0xa1, 0x01,           // Collection (Application)
-  0xa1, 0x00,           // Collection (Physical)
-  0x85, 0x01,           // Report ID
-  0x16, 0xAA, 0xFE,     // Logical Minimum (-350) (0xFEAA in little-endian)
-  0x26, 0x5E, 0x01,     // Logical Maximum (350) (0x015E in little-endian)
-  0x36, 0x88, 0xFA,     // Physical Minimum (-1400) (0xFA88 in little-endian)
-  0x46, 0x70, 0x05,     // Physical Maximum (1400) (0x0570 in little-endian)
-  0x09, 0x30,           // Usage (X)
-  0x09, 0x31,           // Usage (Y)
-  0x09, 0x32,           // Usage (Z)
-  0x75, 0x10,           // Report Size (16)
-  0x95, 0x03,           // Report Count (3)
-  0x81, 0x02,           // Input (variable,absolute)
-  0xC0,                 // End Collection
-  0xa1, 0x00,           // Collection (Physical)
-  0x85, 0x02,           // Report ID
-  0x16, 0xAA, 0xFE,     // Logical Minimum (-350)
-  0x26, 0x5E, 0x01,     // Logical Maximum (350)
-  0x36, 0x88, 0xFA,     // Physical Minimum (-1400)
-  0x46, 0x70, 0x05,     // Physical Maximum (1400)
-  0x09, 0x33,           // Usage (RX)
-  0x09, 0x34,           // Usage (RY)
-  0x09, 0x35,           // Usage (RZ)
-  0x75, 0x10,           // Report Size (16)
-  0x95, 0x03,           // Report Count (3)
-  0x81, 0x02,           // Input (variable,absolute)
-  0xC0,                 // End Collection
-  0xa1, 0x00,           // Collection (Physical)
-  0x85, 0x03,           //  Report ID
-  0x15, 0x00,           //   Logical Minimum (0)
-  0x25, 0x01,           //    Logical Maximum (1)
-  0x75, 0x01,           //    Report Size (1)
-  0x95, 32,             //    Report Count (24)
-  0x05, 0x09,           //    Usage Page (Button)
-  0x19, 1,              //    Usage Minimum (Button #1)
-  0x29, 32,             //    Usage Maximum (Button #24)
-  0x81, 0x02,           //    Input (variable,absolute)
+  0x05, 0x01,        // Usage Page (Generic Desktop)
+  0x09, 0x08,        // Usage (Multi-Axis)
+  0xa1, 0x01,        // Collection (Application)
+  0xa1, 0x00,        // Collection (Physical)
+  0x85, 0x01,        // Report ID
+  0x16, 0xAA, 0xFE,  // Logical Minimum (-350) (0xFEAA in little-endian)
+  0x26, 0x5E, 0x01,  // Logical Maximum (350) (0x015E in little-endian)
+  0x36, 0x88, 0xFA,  // Physical Minimum (-1400) (0xFA88 in little-endian)
+  0x46, 0x70, 0x05,  // Physical Maximum (1400) (0x0570 in little-endian)
+  0x09, 0x30,        // Usage (X)
+  0x09, 0x31,        // Usage (Y)
+  0x09, 0x32,        // Usage (Z)
+  0x75, 0x10,        // Report Size (16)
+  0x95, 0x03,        // Report Count (3)
+  0x81, 0x02,        // Input (variable,absolute)
+  0xC0,              // End Collection
+  0xa1, 0x00,        // Collection (Physical)
+  0x85, 0x02,        // Report ID
+  0x16, 0xAA, 0xFE,  // Logical Minimum (-350)
+  0x26, 0x5E, 0x01,  // Logical Maximum (350)
+  0x36, 0x88, 0xFA,  // Physical Minimum (-1400)
+  0x46, 0x70, 0x05,  // Physical Maximum (1400)
+  0x09, 0x33,        // Usage (RX)
+  0x09, 0x34,        // Usage (RY)
+  0x09, 0x35,        // Usage (RZ)
+  0x75, 0x10,        // Report Size (16)
+  0x95, 0x03,        // Report Count (3)
+  0x81, 0x02,        // Input (variable,absolute)
+  0xC0,              // End Collection
+  0xa1, 0x00,        // Collection (Physical)
+  0x85, 0x03,        //  Report ID
+  0x15, 0x00,        //   Logical Minimum (0)
+  0x25, 0x01,        //    Logical Maximum (1)
+  0x75, 0x01,        //    Report Size (1)
+  0x95, 32,          //    Report Count (24)
+  0x05, 0x09,        //    Usage Page (Button)
+  0x19, 1,           //    Usage Minimum (Button #1)
+  0x29, 32,          //    Usage Maximum (Button #24)
+  0x81, 0x02,        //    Input (variable,absolute)
   0xC0,
   0xC0
 };
@@ -71,13 +76,10 @@ int totalSensitivity = 350;
 // Centerpoint variable to be populated during setup routine.
 int centerPoints[8];
 
-// Variables to read of the keys
-int keyList[NUMKEYS] = {K0, K1, K2, K3};
-int keyVals[NUMKEYS]; //store raw value of the keys, without debouncing
-//Needed for key evaluation
+//store raw value of the keys, without debouncing
+int keyVals[NUMKEYS];
+// final value of the keys, after debouncing
 uint8_t keyOut[NUMKEYS];
-int8_t key_waspressed[NUMKEYS];
-unsigned long timestamp[NUMKEYS];
 
 //Modifier Functions
 int modifierFunction(int x) {
@@ -86,13 +88,13 @@ int modifierFunction(int x) {
   double result;
 #if (modFunc == 1)
   // using squared function y = x^2*sign(x)
-  result = 350 * pow(x / 350.0, 2) * sign(x); //sign putting out -1 or 1 depending on sign of value. (Is needed because x^2 will always be positive)
+  result = 350 * pow(x / 350.0, 2) * sign(x);  //sign putting out -1 or 1 depending on sign of value. (Is needed because x^2 will always be positive)
 #elif (modFunc == 2)
   // using tan function: tan(x)
   result = 350 * tan(x / 350.0);
 #elif (modFunc == 3)
   // using squared tan function: tan(x^2*sign(x))
-  result = 350 * tan(pow(x / 350.0, 2) * sign(x)); //sign putting out -1 or 1 depending on sign of value. (Is needed because x^2 will always be positive)
+  result = 350 * tan(pow(x / 350.0, 2) * sign(x));  //sign putting out -1 or 1 depending on sign of value. (Is needed because x^2 will always be positive)
 #elif (modFunc == 4)
   //using cubed tan function: tan(x^3)
   result = 350 * tan(pow(x / 350.0, 3));
@@ -108,7 +110,7 @@ int modifierFunction(int x) {
   return (int)round(result);
 }
 
-
+// define an array for reading the analog pins of the joysticks
 int pinList[8] = PINLIST;
 
 // Function to read and store analogue voltages for each joystick axis.
@@ -118,19 +120,11 @@ void readAllFromJoystick(int *rawReads) {
   }
 }
 
-// Function to read and store the digital states for each of the keys
-void readAllFromKeys(int *keyVals) {
-  for (int i = 0; i < NUMKEYS; i++) {
-    keyVals[i] = digitalRead(keyList[i]);
-  }
-}
-
 void setup() {
-  //LivingTheDream added
-  /* Setting up the switches */
-  for (int i = 0; i < NUMKEYS; i++) {
-    pinMode(keyList[i], INPUT_PULLUP);
-  }
+// setup the keys e.g. to internal pull-ups
+#if NUMKEYS > 0
+  setupKeys();
+#endif
 
   // HID protocol is set.
   static HIDSubDescriptor node(_hidReportDescriptor, sizeof(_hidReportDescriptor));
@@ -138,11 +132,10 @@ void setup() {
   // Begin Seral for debugging
   Serial.begin(250000);
   delay(100);
-  Serial.setTimeout(2); // the serial interface will look for new debug values and it will only wait 2ms
+  Serial.setTimeout(2);  // the serial interface will look for new debug values and it will only wait 2ms
   // Read idle/centre positions for joysticks.
   readAllFromJoystick(centerPoints);
   delay(100);
-  Serial.println("Please enter the debug mode now or while the script is reporting. -1 to shut off.");
 }
 
 // Function to send translation and rotation data to the 3DConnexion software using the HID protocol outlined earlier. Two sets of data are sent: translation and then rotation.
@@ -153,10 +146,11 @@ void send_command(int16_t rx, int16_t ry, int16_t rz, int16_t x, int16_t y, int1
   uint8_t rot[6] = { rx & 0xFF, rx >> 8, ry & 0xFF, ry >> 8, rz & 0xFF, rz >> 8 };
   HID().SendReport(2, rot, 6);
 
-  if (NUMKEYS > 0) {
-    // LivingTheDream added
-    HID().SendReport(3, keys, NUMKEYS);
-  }
+#if (NUMKEYS > 0)
+  // LivingTheDream added
+  // Send the keys marked as HIDKEYS
+  HID().SendReport(3, keys, NUMHIDKEYS);
+#endif
 }
 
 int rawReads[8], centered[8];
@@ -168,12 +162,12 @@ int16_t velocity[8];
 int minVals[8] = MINVALS;
 int maxVals[8] = MAXVALS;
 
-int tmpInput; // store the value, the user might input over the serial
+int tmpInput;  // store the value, the user might input over the serial
 
 void loop() {
   //check if the user entered a debug mode via serial interface
   if (Serial.available()) {
-    tmpInput = Serial.parseInt(); // Read from serial interface, if a new debug value has been sent. Serial timeout has been set in setup()
+    tmpInput = Serial.parseInt();  // Read from serial interface, if a new debug value has been sent. Serial timeout has been set in setup()
     if (tmpInput != 0) {
       debug = tmpInput;
       if (tmpInput == -1) {
@@ -185,9 +179,10 @@ void loop() {
   // Joystick values are read. 0-1023
   readAllFromJoystick(rawReads);
 
+#if NUMKEYS > 0
   // LivingTheDream added reading of key presses
   readAllFromKeys(keyVals);
-
+#endif
   // Report back 0-1023 raw ADC 10-bit values if enabled
   if (debug == 1) {
     debugOutput1(rawReads, keyVals);
@@ -199,7 +194,7 @@ void loop() {
   }
 
   if (debug == 20) {
-    calcMinMax(centered); // debug=20 to calibrate MinMax values
+    calcMinMax(centered);  // debug=20 to calibrate MinMax values
   }
 
   // Report centered joystick values if enabled. Values should be approx -500 to +500, jitter around 0 at idle
@@ -211,13 +206,11 @@ void loop() {
   for (int i = 0; i < 8; i++) {
     if (centered[i] < DEADZONE && centered[i] > -DEADZONE) {
       centered[i] = 0;
-    }
-    else {
-      if (centered[i] < 0) { //if the value is smaller 0 ...
+    } else {
+      if (centered[i] < 0) {  //if the value is smaller 0 ...
         // ... map the value from the [min,0] to [-350,0]
         centered[i] = map(centered[i], minVals[i], 0, -totalSensitivity, 0);
-      }
-      else { // if the value is > 0 ...
+      } else {  // if the value is > 0 ...
         // ... map the values from the [0,max] to [0,+350]
         centered[i] = map(centered[i], 0, maxVals[i], 0, totalSensitivity);
       }
@@ -230,67 +223,44 @@ void loop() {
   }
 
   // transX
-  velocity[TRANSX] = (-centered[CY] + centered[AY]) / ((float) TRANSX_SENSITIVITY);
-  velocity[TRANSX] = modifierFunction(velocity[TRANSX]); //recalculate with modifier function
+  velocity[TRANSX] = (-centered[CY] + centered[AY]) / ((float)TRANSX_SENSITIVITY);
+  velocity[TRANSX] = modifierFunction(velocity[TRANSX]);  //recalculate with modifier function
 
   // transY
-  velocity[TRANSY] = (-centered[BY] + centered[DY]) / ((float) TRANSY_SENSITIVITY);
-  velocity[TRANSY] = modifierFunction(velocity[TRANSY]); //recalculate with modifier function
+  velocity[TRANSY] = (-centered[BY] + centered[DY]) / ((float)TRANSY_SENSITIVITY);
+  velocity[TRANSY] = modifierFunction(velocity[TRANSY]);  //recalculate with modifier function
 
   velocity[TRANSZ] = -centered[AX] - centered[BX] - centered[CX] - centered[DX];
   if (velocity[TRANSZ] < 0) {
-    velocity[TRANSZ] = modifierFunction(velocity[TRANSZ] / ((float) NEG_TRANSZ_SENSITIVITY)); //recalculate with modifier function
+    velocity[TRANSZ] = modifierFunction(velocity[TRANSZ] / ((float)NEG_TRANSZ_SENSITIVITY));  //recalculate with modifier function
     if (abs(velocity[TRANSZ]) < GATE_NEG_TRANSZ) {
       velocity[TRANSZ] = 0;
     }
-  } else { // pulling the knob upwards is much heavier... smaller factor
-    velocity[TRANSZ] = constrain(velocity[TRANSZ] / ((float) POS_TRANSZ_SENSITIVITY), -350, 350); // no modifier function, just constrain linear!
+  } else {                                                                                        // pulling the knob upwards is much heavier... smaller factor
+    velocity[TRANSZ] = constrain(velocity[TRANSZ] / ((float)POS_TRANSZ_SENSITIVITY), -350, 350);  // no modifier function, just constrain linear!
   }
 
   // rotX
   velocity[ROTX] = (-centered[CX] + centered[AX]) / ((float)ROTX_SENSITIVITY);
-  velocity[ROTX] = modifierFunction(velocity[ROTX]); //recalculate with modifier function
+  velocity[ROTX] = modifierFunction(velocity[ROTX]);  //recalculate with modifier function
   if (abs(velocity[ROTX]) < GATE_ROTX) {
     velocity[ROTX] = 0;
   }
 
   // rotY
   velocity[ROTY] = (-centered[BX] + centered[DX]) / ((float)ROTY_SENSITIVITY);
-  velocity[ROTY] = modifierFunction(velocity[ROTY]); //recalculate with modifier function
+  velocity[ROTY] = modifierFunction(velocity[ROTY]);  //recalculate with modifier function
   if (abs(velocity[ROTY]) < GATE_ROTY) {
     velocity[ROTY] = 0;
   }
 
   // rotZ
   velocity[ROTZ] = (centered[AY] + centered[BY] + centered[CY] + centered[DY]) / ((float)ROTZ_SENSITIVITY);
-  velocity[ROTZ] = modifierFunction(velocity[ROTZ]); //recalculate with modifier function
+  velocity[ROTZ] = modifierFunction(velocity[ROTZ]);  //recalculate with modifier function
   if (abs(velocity[ROTZ]) < GATE_ROTZ) {
     velocity[ROTZ] = 0;
   }
 
-  //Button Evaluation
-  for (int i = 0; i < NUMKEYS; i++) {
-    if (keyVals[i]) {
-      // Making sure button cannot trigger multiple times which would result in overloading HID.
-      if (key_waspressed[i] == 0) { // if the button has not been pressed lately:
-        keyOut[i] = 1;
-        key_waspressed[i] = 1;
-        timestamp[i] = millis(); // remember the time, the button was pressed
-        Serial.print("Key: "); // this is always sent, and not only in debug
-        Serial.println(i);
-      } else { // the button was already pressed (and the event sent in the last loop), don't send the keyOut event again.
-        keyOut[i] = 0;
-      }
-    } else { // the button is not pressed
-      if (key_waspressed[i] == 1) { // has it been pressed lately?
-        //Debouncing
-        if (millis() - timestamp[i] > DEBOUNCE_KEYS_MS) { // check if the last button press is long enough in the past
-          key_waspressed[i] = 0; // reset this marker and allow a new button press
-        }
-      }
-
-    }
-  }
   // Invert directions if needed
 #if INVX > 0
   velocity[TRANSX] = velocity[TRANSX] * -1;
@@ -311,6 +281,10 @@ void loop() {
   velocity[ROTZ] = velocity[ROTZ] * -1;
 #endif
 
+#if NUMKEYS > 0
+  evalKeys(keyVals, keyOut);
+#endif
+
   if (debug == 4) {
     debugOutput4(velocity, keyOut);
     // Report translation and rotation values if enabled. Approx -800 to 800 depending on the parameter.
@@ -320,10 +294,31 @@ void loop() {
   }
   // Report debug 4 and 5 info side by side for direct reference if enabled. Very useful if you need to alter which inputs are used in the arithmatic above.
 
+  // if the kill-key feature is enabled, rotations or translations are killed=set to zero
+#if (NUMKILLKEYS == 2)
+  if (keyVals[KILLROT] == LOW) {  // check for the raw keyVal and not keyOut, because keyOut is only 1 for a single iteration. keyVals has inverse Logic due to pull-ups
+    // kill rotation
+    velocity[ROTX] = 0;
+    velocity[ROTY] = 0;
+    velocity[ROTZ] = 0;
+  }
+  if (keyVals[KILLTRANS] == LOW) {
+    // kill translation
+    velocity[TRANSX] = 0;
+    velocity[TRANSY] = 0;
+    velocity[TRANSZ] = 0;
+  }
+#endif
+
+  // report velocity and keys after possible kill-key feature
+  if (debug == 6) {
+    debugOutput4(velocity, keyOut);
+  }
+
   // Send data to the 3DConnexion software.
   // The correct order for TeachingTech was determined after trial and error
 #if SWITCHYZ > 0
-  //Original from TT, but 3DConnextion tutorial will not work:
+  // Original from TT, but 3DConnextion tutorial will not work:
   send_command(velocity[ROTX], velocity[ROTZ], velocity[ROTY], velocity[TRANSX], velocity[TRANSZ], velocity[TRANSY], keyOut);
 #else
   // Daniel_1284580 noticed the 3dconnexion tutorial was not working the right way so they got changed


### PR DESCRIPTION
Reimplemented the killKey feature following the idea by https://github.com/JoseLuisGZA/ErgonoMouse @JoseLuisGZA 

When the kill-translation button is pressed, the translation is set to zero and a user can focus on rotation.
Vice-versa with the kill-rotation button: Send only translations.

The user can assign keys to send them via HID or use them as kill-keys or both at the same time.

Therefore: 
Moved the key handling to spacekeys.cpp
Updated readme and config accordingly.