### PR TITLE
Add delay for debug

### DIFF
--- a/spacemouse-keys/spacemouse-keys.ino
+++ b/spacemouse-keys/spacemouse-keys.ino
@@ -318,6 +318,10 @@ void loop() {
   if (debug == 5) {
     debugOutput5(centered, velocity);
   }
+
+  if (debug >= 1) {
+    delayMicroseconds(5000);
+  }
   // Report debug 4 and 5 info side by side for direct reference if enabled. Very useful if you need to alter which inputs are used in the arithmatic above.
 
   // Send data to the 3DConnexion software.


### PR DESCRIPTION
Hi,

here is an addition in order to prevent Arduino IDE to eat all the CPU when displaying the logs sent in debug mode

Regards