### PR TITLE
Added Key support for some first buttons like FIT, T, R, 3 and 4

### DIFF
--- a/spacemouse-keys/calibration.cpp
+++ b/spacemouse-keys/calibration.cpp
@@ -20,8 +20,8 @@ void printArray(int arr[], int size) {
   Serial.println("};");
 }
 
-char* axisNames[] = { "AX:", "AY:", "BX:", "BY:", "CX:", "CY:", "DX:", "DY:" };  // 8
-char* velNames[] = { "TX:", "TY:", "TZ:", "RX:", "RY:", "RZ:" };                 // 6
+char const * axisNames[] = { "AX:", "AY:", "BX:", "BY:", "CX:", "CY:", "DX:", "DY:" };  // 8
+char const * velNames[] = { "TX:", "TY:", "TZ:", "RX:", "RY:", "RZ:" };                 // 6
 
 void debugOutput1(int* rawReads, int* keyVals) {
   if (isDebugOutputDue()) {

--- a/spacemouse-keys/config_sample.h
+++ b/spacemouse-keys/config_sample.h
@@ -20,12 +20,12 @@
 //
 // Try to write down the two axis of every joystick with the corresponding pin numbers you chose. (A4 and A5 are not used in the example by TeachingTech).
 // Compile the script, type 1 into the serial interface and hit enter to enable debug output 1.
-// Now: At the joystick in front of you (A), move the joystick from top to bottom (X). 
+// Now: At the joystick in front of you (A), move the joystick from top to bottom (X).
 // If everything is correct: The debug output for AX should show values from 0 to 1023.
 // If another output is showing this values, swap them. Probably you have to swap the first and second element, as AX and AY may be swapped.
-// If you have the joystick TeachingTech recommended: 
-//     The pins labelled X and Y on the joystick are NOT the X and Y needed here, but swapped. First joysticks Y: AX and X: AY. 
-// 
+// If you have the joystick TeachingTech recommended:
+//     The pins labelled X and Y on the joystick are NOT the X and Y needed here, but swapped. First joysticks Y: AX and X: AY.
+//
 // Repeat this with every axis and every joystick.
 
 // AX, AY, BX, BY, CX, CY, DX, DY
@@ -44,6 +44,7 @@
 // 5: Output debug 4 and 5 side by side for direct cause and effect reference.
 // 6: Report velocity and keys after possible kill-key feature
 // 7: Report the frequency of the loop() -> how often is the loop() called in one second?
+// 8: Report the bits and bytes send as button codes
 #define STARTDEBUG 0
 
 // Modifier Function
@@ -129,7 +130,7 @@
 
 // ------------------------------------------------------------------------------------
 // Direction
-// Modify the direction of translation/rotation depending on preference. 
+// Modify the direction of translation/rotation depending on preference.
 // This should be done, when you are done with the pin assignment.
 // The default 0 is here for x, y and z orientation as to the picture in the readem
 // The suggestion in the comments is to accomodate the 3dConnexion Trainer "3Dc"
@@ -149,12 +150,39 @@
 // Keys Support
 // How many keys are there in total?
 #define NUMKEYS 4
-// Define the pins for the keys
+// Define the pins for the keys on the arduino
 // the first pins are reported via HID
 #define KEYLIST \
   { 15, 14, 16, 10 }
 // How many keys reported?
-#define NUMHIDKEYS 2
+#define NUMHIDKEYS 4
+
+// In order to define which key is assigned to which button, the following list must be entered in the BUTTONLIST below
+
+// #define ??     0  // Key ?
+#define SM_FIT 1 // Key "Fit"
+#define SM_T 2   // Key "T" top
+// #define ??     3  // Key ?
+#define SM_R 4 // Key "R" right
+#define SM_F 5 // Key "F" Front
+// #define ??     6  // Key ?
+// #define ??     7  // Key ?
+#define SM_CA 8 // Key Rotate 90° ("ca = cube with arrow")
+// #define ??     9  // Key ?
+// #define ??     10 // Key ?
+// #define ??     11 // Key ?
+#define SM_4 12 // Key "4" sketch
+// #define ??     13 // Key ?
+#define SM_3 14 // Key "3" Partools
+// #define ??   15 //  Key ?
+
+// BUTTONLIST must have the so many elemets as NUMHIDKEYS is set
+// The keys are from KEYLIST are assigned buttons here:
+#define BUTTONLIST            \
+  {                           \
+    SM_FIT, SM_T, SM_R, SM_CA \
+  }
+// ------------------------------------------------------------------------------------
 
 // Kill-Key Feature: Are there buttons to set the translation or rotation to zero?
 // How many kill keys are there? (disabled: 0; enabled: 2)
@@ -171,17 +199,19 @@
  *  The keys which shall be reported to the pc are connected to pin 15, 14 and 16
  *  KEYLIST {15, 14, 16}
  *  Therefore, the first three pins from the KEYLIST apply for the HID: NUMHIDKEYS 3
+ *  Those three Buttons shall be "FIT", "T" and "R": BUTTONLIST {SM_FIT, SM_T, SM_R}
  *  No keys for kill-keys NUMKILLKEYS 0
  *  KILLROT and KILLTRANS don't matter... KILLROT 0 and KILLTRANS 0
-*/
+ */
 
-/* 
+/*
  *  Example for two usual buttons and two kill-keys:
  *  There are four keys in total:  NUMKEYS 4
  *  The keys which shall be reported to the pc are connected to pin 15 and 14
  *  The keys which shall be used to kill translation or rotation are connected to pin 16 and 10
  *  KEYLIST {15, 14, 16, 10}
  *  Therefore, the first two pins from the KEYLIST apply for the HID: NUMHIDKEYS 2
+ *  Those two Buttons shall be "3", "4": BUTTONLIST {SM_3, SM_4}
  *  Two keys are used as kill-keys: NUMKILLKEYS 2
  *  The first kill key has the third position in the KEYLIST and due to zero-based counting third-1 => KILLROT 2
  *  The second kill key has the last position in the KEYLIST with index 3 -> KILLTRANS 3

--- a/spacemouse-keys/config_sample.h
+++ b/spacemouse-keys/config_sample.h
@@ -49,13 +49,14 @@
 
 // Modifier Function
 // Modify resulting behaviour of Joystick input values
-// DISCLAIMER: This should be at level 0 when starting the calibration
+// DISCLAIMER: This should be at level 0 when starting the calibration!
 // 0: linear y = x [Standard behaviour: No modification]
 // 1: squared function y = x^2*sign(x) [altered squared function working in positive and negative direction]
 // 2: tangent function: y = tan(x) [Results in a flat curve near zero but increases the more you are away from zero]
 // 3: squared tangent function: y = tan(x^2*sign(X)) [Results in a flatter curve near zero but increases alot the more you are away from zero]
 // 4: cubed tangent function: y = tan(x^3) [Results in a very flat curve near zero but increases drastically the more you are away from zero]
-#define MODFUNC 3
+// Recommendation after tuning: MODFUNC 3
+#define MODFUNC 0
 
 // Second calibration: Tune Deadzone
 // Deadzone to filter out unintended movements. Increase if the mouse has small movements when it should be idle or the mouse is too senstive to subtle movements.
@@ -176,8 +177,8 @@
 #define SM_3 14 // Key "3" Partools
 // #define ??   15 //  Key ?
 
-// BUTTONLIST must have the so many elemets as NUMHIDKEYS is set
-// The keys are from KEYLIST are assigned buttons here:
+// BUTTONLIST must have the as many elemets as NUMHIDKEYS
+// The keys from KEYLIST are assigned buttons here:
 #define BUTTONLIST            \
   {                           \
     SM_FIT, SM_T, SM_R, SM_CA \
@@ -223,6 +224,5 @@
 #if (NUMKILLKEYS > 0 && ((KILLROT > NUMKEYS) || (KILLTRANS > NUMKEYS)))
 #error "Index of killkeys must be smaller than the total number of keys"
 #endif
-
 
 #define DEBOUNCE_KEYS_MS 200  // time in ms which is needed to allow a new button press

--- a/spacemouse-keys/hidInterface.cpp
+++ b/spacemouse-keys/hidInterface.cpp
@@ -1,0 +1,52 @@
+#include <Arduino.h>
+#include "config.h"
+#include "hidInterface.h"
+// Include inbuilt Arduino HID library by NicoHood: https://github.com/NicoHood/HID
+#include "HID.h"
+
+// Array with the bitnumbers, which should be assign keys to buttons
+uint8_t bitNumber[NUMHIDKEYS] = BUTTONLIST;
+
+// Function to send translation and rotation data to the 3DConnexion software using the HID protocol outlined earlier. Two sets of data are sent: translation and then rotation.
+// For each, a 16bit integer is split into two using bit shifting. The first is mangitude and the second is direction.
+void send_command(int16_t rx, int16_t ry, int16_t rz, int16_t x, int16_t y, int16_t z, uint8_t *keys, int debug)
+{
+  uint8_t trans[6] = {x & 0xFF, x >> 8, y & 0xFF, y >> 8, z & 0xFF, z >> 8};
+  HID().SendReport(1, trans, 6);
+  uint8_t rot[6] = {rx & 0xFF, rx >> 8, ry & 0xFF, ry >> 8, rz & 0xFF, rz >> 8};
+  HID().SendReport(2, rot, 6);
+
+#if (NUMKEYS > 0)
+  static uint8_t data[HIDMAXBUTTONS / 8];     // array to be sent over hid
+  for (int i = 0; i < HIDMAXBUTTONS / 8; i++) // init or empty this array
+  {
+    data[i] = 0;
+  }
+
+  for (int i = 0; i < NUMHIDKEYS; i++)
+  {
+    // check for every key if it is pressed
+    if (keys[i])
+    {
+      // set the according bit in the data bytes
+      // byte no.: bitNumber[i] / 8
+      // bit no.:  bitNumber[i] modulo 8
+      data[(bitNumber[i] / 8)] = (1 << (bitNumber[i] % 8));
+      if (debug == 8)
+      {
+        // debug the key board outputs
+        Serial.print("bitnumber: ");
+        Serial.print(bitNumber[i]);
+        Serial.print(" -> data[");
+        Serial.print((bitNumber[i] / 8));
+        Serial.print("] = ");
+        Serial.print("0x");
+        Serial.println(data[(bitNumber[i] / 8)], HEX);
+      }
+    }
+  }
+
+  HID().SendReport(3, data, HIDMAXBUTTONS / 8);
+
+#endif
+}

--- a/spacemouse-keys/hidInterface.cpp
+++ b/spacemouse-keys/hidInterface.cpp
@@ -11,9 +11,9 @@ uint8_t bitNumber[NUMHIDKEYS] = BUTTONLIST;
 // For each, a 16bit integer is split into two using bit shifting. The first is mangitude and the second is direction.
 void send_command(int16_t rx, int16_t ry, int16_t rz, int16_t x, int16_t y, int16_t z, uint8_t *keys, int debug)
 {
-  uint8_t trans[6] = {x & 0xFF, x >> 8, y & 0xFF, y >> 8, z & 0xFF, z >> 8};
+  uint8_t trans[6] = {(byte)(x & 0xFF), (byte)(x >> 8), (byte)(y & 0xFF), (byte)(y >> 8), (byte)(z & 0xFF), (byte)(z >> 8)};
   HID().SendReport(1, trans, 6);
-  uint8_t rot[6] = {rx & 0xFF, rx >> 8, ry & 0xFF, ry >> 8, rz & 0xFF, rz >> 8};
+  uint8_t rot[6] = {(byte)(rx & 0xFF), (byte)(rx >> 8), (byte)(ry & 0xFF), (byte)(ry >> 8), (byte)(rz & 0xFF), (byte)(rz >> 8)};
   HID().SendReport(2, rot, 6);
 
 #if (NUMKEYS > 0)

--- a/spacemouse-keys/hidInterface.h
+++ b/spacemouse-keys/hidInterface.h
@@ -1,0 +1,51 @@
+//hidInterface.h
+
+// This portion sets up the communication with the 3DConnexion software. The communication protocol is created here.
+// hidReportDescriptor webpage can be found here: https://eleccelerator.com/tutorial-about-usb-hid-report-descriptors/
+// Altered physical, logical range to ranges the 3DConnexion software expects by Daniel_1284580.
+#define HIDMAXBUTTONS 24 // was 32 by Daniel_1284580, but 24 in the comment... must be multiple of 8!
+
+static const uint8_t _hidReportDescriptor[] PROGMEM = {
+    0x05, 0x01,          // Usage Page (Generic Desktop)
+    0x09, 0x08,          // Usage (Multi-Axis)
+    0xa1, 0x01,          // Collection (Application)
+    0xa1, 0x00,          // Collection (Physical)
+    0x85, 0x01,          // Report ID
+    0x16, 0xAA, 0xFE,    // Logical Minimum (-350) (0xFEAA in little-endian)
+    0x26, 0x5E, 0x01,    // Logical Maximum (350) (0x015E in little-endian)
+    0x36, 0x88, 0xFA,    // Physical Minimum (-1400) (0xFA88 in little-endian)
+    0x46, 0x70, 0x05,    // Physical Maximum (1400) (0x0570 in little-endian)
+    0x09, 0x30,          // Usage (X)
+    0x09, 0x31,          // Usage (Y)
+    0x09, 0x32,          // Usage (Z)
+    0x75, 0x10,          // Report Size (16)
+    0x95, 0x03,          // Report Count (3)
+    0x81, 0x02,          // Input (variable,absolute)
+    0xC0,                // End Collection
+    0xa1, 0x00,          // Collection (Physical)
+    0x85, 0x02,          // Report ID
+    0x16, 0xAA, 0xFE,    // Logical Minimum (-350)
+    0x26, 0x5E, 0x01,    // Logical Maximum (350)
+    0x36, 0x88, 0xFA,    // Physical Minimum (-1400)
+    0x46, 0x70, 0x05,    // Physical Maximum (1400)
+    0x09, 0x33,          // Usage (RX)
+    0x09, 0x34,          // Usage (RY)
+    0x09, 0x35,          // Usage (RZ)
+    0x75, 0x10,          // Report Size (16)
+    0x95, 0x03,          // Report Count (3)
+    0x81, 0x02,          // Input (variable,absolute)
+    0xC0,                // End Collection
+    0xa1, 0x00,          // Collection (Physical)
+    0x85, 0x03,          //  Report ID
+    0x15, 0x00,          //   Logical Minimum (0)
+    0x25, 0x01,          //    Logical Maximum (1)
+    0x75, 0x01,          //    Report Size (1)
+    0x95, HIDMAXBUTTONS, //    Report Count (24) // has been 32 in earlier versions
+    0x05, 0x09,          //    Usage Page (Button)
+    0x19, 1,             //    Usage Minimum (Button #1)
+    0x29, HIDMAXBUTTONS, //    Usage Maximum (Button #24) // has been 32 in earlier versions
+    0x81, 0x02,          //    Input (variable,absolute)
+    0xC0,
+    0xC0};
+
+    void send_command(int16_t rx, int16_t ry, int16_t rz, int16_t x, int16_t y, int16_t z, uint8_t *keys, int debug);

--- a/spacemouse-keys/spacemouse-keys.ino
+++ b/spacemouse-keys/spacemouse-keys.ino
@@ -21,57 +21,13 @@
 // header file for reading the keys
 #include "spaceKeys.h"
 
+// header for HID emulation of the spacemouse
+#include "hidInterface.h"
+
 // the debug mode can be set during runtime via the serial interface
 int debug = STARTDEBUG;
 
-// This portion sets up the communication with the 3DConnexion software. The communication protocol is created here.
-// hidReportDescriptor webpage can be found here: https://eleccelerator.com/tutorial-about-usb-hid-report-descriptors/
-// Altered physical, logical range to ranges the 3DConnexion software expects by Daniel_1284580.
-static const uint8_t _hidReportDescriptor[] PROGMEM = {
-  0x05, 0x01,        // Usage Page (Generic Desktop)
-  0x09, 0x08,        // Usage (Multi-Axis)
-  0xa1, 0x01,        // Collection (Application)
-  0xa1, 0x00,        // Collection (Physical)
-  0x85, 0x01,        // Report ID
-  0x16, 0xAA, 0xFE,  // Logical Minimum (-350) (0xFEAA in little-endian)
-  0x26, 0x5E, 0x01,  // Logical Maximum (350) (0x015E in little-endian)
-  0x36, 0x88, 0xFA,  // Physical Minimum (-1400) (0xFA88 in little-endian)
-  0x46, 0x70, 0x05,  // Physical Maximum (1400) (0x0570 in little-endian)
-  0x09, 0x30,        // Usage (X)
-  0x09, 0x31,        // Usage (Y)
-  0x09, 0x32,        // Usage (Z)
-  0x75, 0x10,        // Report Size (16)
-  0x95, 0x03,        // Report Count (3)
-  0x81, 0x02,        // Input (variable,absolute)
-  0xC0,              // End Collection
-  0xa1, 0x00,        // Collection (Physical)
-  0x85, 0x02,        // Report ID
-  0x16, 0xAA, 0xFE,  // Logical Minimum (-350)
-  0x26, 0x5E, 0x01,  // Logical Maximum (350)
-  0x36, 0x88, 0xFA,  // Physical Minimum (-1400)
-  0x46, 0x70, 0x05,  // Physical Maximum (1400)
-  0x09, 0x33,        // Usage (RX)
-  0x09, 0x34,        // Usage (RY)
-  0x09, 0x35,        // Usage (RZ)
-  0x75, 0x10,        // Report Size (16)
-  0x95, 0x03,        // Report Count (3)
-  0x81, 0x02,        // Input (variable,absolute)
-  0xC0,              // End Collection
-  0xa1, 0x00,        // Collection (Physical)
-  0x85, 0x03,        //  Report ID
-  0x15, 0x00,        //   Logical Minimum (0)
-  0x25, 0x01,        //    Logical Maximum (1)
-  0x75, 0x01,        //    Report Size (1)
-  0x95, 32,          //    Report Count (24)
-  0x05, 0x09,        //    Usage Page (Button)
-  0x19, 1,           //    Usage Minimum (Button #1)
-  0x29, 32,          //    Usage Maximum (Button #24)
-  0x81, 0x02,        //    Input (variable,absolute)
-  0xC0,
-  0xC0
-};
-
-//Please do not change this anymore. Use indipendent sensitivity multiplier.
+// Please do not change this anymore. Use indipendent sensitivity multiplier.
 int totalSensitivity = 350;
 // Centerpoint variable to be populated during setup routine.
 int centerPoints[8];
@@ -136,21 +92,6 @@ void setup() {
   // Read idle/centre positions for joysticks.
   readAllFromJoystick(centerPoints);
   delay(100);
-}
-
-// Function to send translation and rotation data to the 3DConnexion software using the HID protocol outlined earlier. Two sets of data are sent: translation and then rotation.
-// For each, a 16bit integer is split into two using bit shifting. The first is mangitude and the second is direction.
-void send_command(int16_t rx, int16_t ry, int16_t rz, int16_t x, int16_t y, int16_t z, uint8_t *keys) {
-  uint8_t trans[6] = { x & 0xFF, x >> 8, y & 0xFF, y >> 8, z & 0xFF, z >> 8 };
-  HID().SendReport(1, trans, 6);
-  uint8_t rot[6] = { rx & 0xFF, rx >> 8, ry & 0xFF, ry >> 8, rz & 0xFF, rz >> 8 };
-  HID().SendReport(2, rot, 6);
-
-#if (NUMKEYS > 0)
-  // LivingTheDream added
-  // Send the keys marked as HIDKEYS
-  HID().SendReport(3, keys, NUMHIDKEYS);
-#endif
 }
 
 int rawReads[8], centered[8];

--- a/spacemouse-keys/spacemouse-keys.ino
+++ b/spacemouse-keys/spacemouse-keys.ino
@@ -259,10 +259,10 @@ void loop() {
   // The correct order for TeachingTech was determined after trial and error
 #if SWITCHYZ > 0
   // Original from TT, but 3DConnextion tutorial will not work:
-  send_command(velocity[ROTX], velocity[ROTZ], velocity[ROTY], velocity[TRANSX], velocity[TRANSZ], velocity[TRANSY], keyOut);
+  send_command(velocity[ROTX], velocity[ROTZ], velocity[ROTY], velocity[TRANSX], velocity[TRANSZ], velocity[TRANSY], keyOut, debug);
 #else
   // Daniel_1284580 noticed the 3dconnexion tutorial was not working the right way so they got changed
-  send_command(velocity[ROTX], velocity[ROTY], velocity[ROTZ], velocity[TRANSX], velocity[TRANSY], velocity[TRANSZ], keyOut);
+  send_command(velocity[ROTX], velocity[ROTY], velocity[ROTZ], velocity[TRANSX], velocity[TRANSY], velocity[TRANSZ], keyOut, debug);
 #endif
 
   


### PR DESCRIPTION
I added and corrected the routine for sending key events, based on issue #28.

As of now I found out the Keys for:
- "Fit"
- "T" top
- "R" right
- "F" Front
-  Rotate 90° ("ca = cube with arrow")
- "4" sketch
- "3" Partools

I opened onshape in the browser and tried every of the first 15 bits, if they produce some output and mapped them to the 3dconnexion software. 
**Please test it** and find the missing bit/key combinations!

Hint: 
I didn't had to use the scrambled assignment of the libspacenav, which was shown to me here: https://github.com/FreeSpacenav/spacenavd/discussions/74 and
https://github.com/FreeSpacenav/spacenavd/blob/c6f8a6bf4aa5024c0317f4bb215f828e4219d61f/src/dev.c#L442 
But maybe it helps someone... ? 