### PR TITLE
Add protocol-explicit <action>.tool properties required for pluggable discovery compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Here is the addition, which needs to be copied into the boards.txt (e.g. at the 
 spacemouse.name=SpaceMouse
 
 spacemouse.upload.tool=avrdude
+spacemouse.upload.tool.default=avrdude
 spacemouse.upload.protocol=avr109
 spacemouse.upload.maximum_size=28672
 spacemouse.upload.maximum_data_size=2560
@@ -73,6 +74,7 @@ spacemouse.upload.use_1200bps_touch=true
 spacemouse.upload.wait_for_upload_port=true
 
 spacemouse.bootloader.tool=avrdude
+spacemouse.bootloader.tool.default=avrdude
 spacemouse.bootloader.unlock_bits=0x3F
 spacemouse.bootloader.lock_bits=0x2F
 spacemouse.bootloader.low_fuses=0xFF
@@ -105,7 +107,6 @@ spacemouse.bootloader.file=caterina/Caterina-promicro16.hex
 - Teaching Tech followed the instructions here from [nebhead](https://gist.github.com/nebhead/c92da8f1a8b476f7c36c032a0ac2592a) with two key differences:
 	- Changed the word 'DaemonBite' to 'Spacemouse' in all references.
   	- Changed the VID and PID values as per jfedor's instructions: vid=0x256f, pid=0xc631 (SpaceMouse Pro Wireless (cabled))
--  Some [people](https://gist.github.com/nebhead/c92da8f1a8b476f7c36c032a0ac2592a?permalink_comment_id=5069434#gistcomment-5069434) need to change ```spacemouse.upload.tool=avrdude``` to ```spacemouse.upload.tool.serial=avrdude``` to avoid ```Property 'upload.tool.serial' is undefined``` when compiling
 
 ## Cloning the github repo
 Clone the github repo to your computer: Scroll-Up to the green "<> Code" Button and select, if you wish to clone or just download the code.


### PR DESCRIPTION
## Background

A new flexible and powerful ["pluggable discovery" system](https://arduino.github.io/arduino-cli/latest/platform-specification/#pluggable-discovery) was added to the Arduino boards platform framework. This system makes it easy for Arduino boards platform authors to use any arbitrary communication channel between the board and development tools.

Boards platform configurations that use the old property syntax are automatically translated to the new syntax by Arduino CLI:

https://arduino.github.io/arduino-cli/latest/platform-specification/#sketch-upload-configuration

> For backward compatibility with IDE 1.8.15 and older the previous syntax is still supported

This translation is only done in platforms that use the old syntax exclusively. If [`pluggable_discovery` properties](https://arduino.github.io/arduino-cli/latest/platform-specification/#pluggable-discovery) are defined for the platform then the new pluggable discovery-style [`upload.tool.<protocol_name>`](https://arduino.github.io/arduino-cli/latest/platform-specification/#sketch-upload-configuration) and [`bootloader.tool.<protocol_name>`](https://arduino.github.io/arduino-cli/dev/platform-specification/#:~:text=bootloader.tool%20property) properties must be defined for each board as well.

## Explanation of `Property 'upload.tool.serial' is undefined` Errors

The project's instructions for [macOS](https://github.com/AndunHH/spacemouse#boardstxt-on-mac) and [Windows](https://github.com/AndunHH/spacemouse#boardstxt-on-windows) users specify modification of the "[**Arduino AVR Boards**](https://github.com/arduino/ArduinoCore-avr)" platform. The "**Arduino AVR Boards**" platform uses the new pluggable discovery platform properties syntax (https://github.com/arduino/ArduinoCore-avr/commit/c34151f2342476c25146bb51dab67fc390a4524e), so the `upload.tool.<protocol_name>` and `bootloader.tool.<protocol_name>` properties are required.

The required properties are missing from the "SpaceMouse" board definition, which causes uploads to fail for users of the recent versions of Arduino IDE and Arduino CLI with the error message:

```text
Error during Upload: Property 'upload.tool.serial' is undefined
```

## Proposed Change

The solution is to add the missing properties to the board definition. I chose to use the [`default`](https://arduino.github.io/arduino-cli/dev/platform-specification/#pluggable-discovery:~:text=When%20the%20user%20tries%20to%20upload%20using%20a%20protocol%20not%20supported%20by%20the%20board%2C%20it%20will%20fallback%20to%20default%20if%20one%20was%20defined) protocol specifier instead of the more specific `serial` protocol specifier for [consistency]((https://github.com/arduino/ArduinoCore-avr/commit/c34151f2342476c25146bb51dab67fc390a4524e)) with the other board definitions in the "Arduino AVR Boards" platform.

### Relevance to Linux Users

Linux users will not experience the `Property 'upload.tool.serial' is undefined` error because, for unknown reasons, [the project's instructions](https://github.com/AndunHH/spacemouse#boardstxt-on-linux) specify the modification of the "[**SparkFun AVR Boards**](https://github.com/sparkfun/Arduino_Boards/tree/main/sparkfun/avr)" platform instead of the "**Arduino AVR Boards**" platform for users of that operating system. The "**SparkFun AVR Boards**" platform does not use the new pluggable discovery platform properties syntax. 

However, even though they are not required, the definition of the `upload.tool.default` and `bootloader.tool.default` properties doesn't do any harm when the board definition is in that platform.

### Backwards Compatibility

It is also important to provide compatibility with versions of Arduino development tools from before the introduction of the modern pluggable discovery system. For this reason, the old style `upload.tool` and `bootloader.tool` properties are retained. Old versions of the development tools will treat the `upload.tool.default` and `bootloader.tool.default` properties as an unused arbitrary user defined property with no special significance and the new versions of the development tools will do the same for the `upload.tool.default` and `bootloader.tool.default` properties.

---

Resolves https://github.com/AndunHH/spacemouse/issues/27