### PR TITLE
do not handle bitNumber wheh NUMKEYS is 0

### DIFF
--- a/spacemouse-keys/hidInterface.cpp
+++ b/spacemouse-keys/hidInterface.cpp
@@ -4,8 +4,10 @@
 // Include inbuilt Arduino HID library by NicoHood: https://github.com/NicoHood/HID
 #include "HID.h"
 
+#if (NUMKEYS > 0)
 // Array with the bitnumbers, which should be assign keys to buttons
 uint8_t bitNumber[NUMHIDKEYS] = BUTTONLIST;
+#endif
 
 // Function to send translation and rotation data to the 3DConnexion software using the HID protocol outlined earlier. Two sets of data are sent: translation and then rotation.
 // For each, a 16bit integer is split into two using bit shifting. The first is mangitude and the second is direction.


### PR DESCRIPTION
Hi,

here is a fix when `NUMKEYS=0`. Previously, I had a compilation error:
```
❯ pio run
...
Compiling .pio/build/micro/src/spaceKeys.cpp.o
Compiling .pio/build/micro/src/spacemouse-keys.ino.cpp.o
In file included from spacemouse-keys/hidInterface.cpp:2:0:
spacemouse-keys/config.h:188:48: error: too many initializers for 'uint8_t [0] {aka unsigned char [0]}'
 #define BUTTONLIST { SM_FIT, SM_T, SM_R, SM_CA }
                                                ^
Compiling .pio/build/micro/FrameworkArduino/HardwareSerial0.cpp.o
spacemouse-keys/hidInterface.cpp:8:33: note: in expansion of macro 'BUTTONLIST'
 uint8_t bitNumber[NUMHIDKEYS] = BUTTONLIST;
                                 ^~~~~~~~~~
Compiling .pio/build/micro/FrameworkArduino/HardwareSerial1.cpp.o
*** [.pio/build/micro/src/hidInterface.cpp.o] Error 1
========================================================================= [FAILED] Took 0.72 seconds =========================================================================
```

Now, it doesn't fail :muscle: 

Regards