### PR TITLE
Add exclusive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-# New Update: Support for neopixel led ring
+# New Update March 2025: Exclusive Mode
 
-December 2024 Update: Support for LED rings like a neopixel! 
+When the exclusive mode is activated in the config.h only the major movement is transmitted. 
+That means, that the mouse detects, if you want to translate or rotate.
 
-![Overview of the spacemouse with neopixel led ring](pictures/neopixel-3dof-mouse.png)
-The adafruit neopixel led ring with an inner diameter of 52.3 mm fits well.
+When the biggest input is a translation: All rotations are set to zero.
 
-Filming the LEDs "in action" is very hard, maybe you can get an idea:
-![animated LED ring animation](pictures/NeoPixelRing-lightning.gif)
+When the biggest input is a rotation: All translations are set to zero.
+
+This function is the sister of the kill-key feature, where you press a key to decide wether only translations or rotations are transmitted.
+
+Thanks to @mamatt in #73 for this suggestion!
 
 # Open Source six degree of freedom (6 DOF) mouse with keys, encoder and more
 Repository for a 3D mouse, which emulates a 3Dconnexion "Space Mouse Pro wireless". (This repository is NOT affiliated with 3Dconnexion. We just reverse-engineered the USB protocoll.)
@@ -32,10 +35,11 @@ To see all features in place, like the buttons and the encoder, check out the di
 - Debug outputs can be requested over the serial interface during run time, see [config_sample.h](spacemouse-keys/config_sample.h#L36) 
 - Over ten keys may be reported to the PC via USB and may be evaluated by the original driver software
 - "Kill-Keys" may disable translation or rotation directly in the mouse
+- Exclusive-Mode: Transmit either translation or rotation and set the other one to zero, depending on what the main motion is.
 - An encoder wheel can be used to replace one axis and allow e.g. zooming
 - Check out the [config_sample.h](spacemouse-keys/config_sample.h) for more informations about configurable elements and extensive debug outputs
 - LED can be enabled by the PC driver
-- Support for a LED ring, as supported by the FastLED library
+- Support for a [LED ring](#support-for-neopixel-led-ring), as supported by the FastLED library
 
 Wanted features:
 - Reverse Direction and Speed options in 3dConnexion Software is not working, because our spacemouse is not accepting this settings.
@@ -175,7 +179,6 @@ Here are some other projects with regard to space mice. The arrow indicates what
 * [spacemouse with an esp32](https://github.com/horvatkm/space_mouse_esp32s2) -> work in progress -> space mouse pro
 * [Space Fox](https://github.com/pepijndevos/spacefox) -> Joystick based on potentiometers
 * [Orbion The OpenSource 3D Space Mouse](https://github.com/FaqT0tum/Orbion_3D_Space_Mouse) -> Mouse and Keyboard
-* 
 
 
 # History
@@ -194,6 +197,20 @@ The basis is fdmakara's four joystick movement logic, with jfedor/BennyBWalker's
 11. Moved the Deadzone detection into the inital ADC conversion and calculate every value everytime and use the modifier for better seperation between the access, By Andun_HH.
 12. Added two additional buttons integrated into the knob to kill either translation or rotation at will and prevent unintended movements, by JoseLuisGZA and AndunHH.
 13. Added Encoder to use with a wheel on top of the main knob an simulate pulls on any of the axis (main use is simulating zoom like the mouse wheel), by [JoseLuizGZA](https://github.com/JoseLuisGZA/ErgonoMouse/) and rewritten by AndunHH.
+
+# Specific features
+
+## Support for neopixel led ring
+
+December 2024 Update: Support for LED rings like a neopixel! 
+
+![Overview of the spacemouse with neopixel led ring](pictures/neopixel-3dof-mouse.png)
+
+The adafruit neopixel led ring with an inner diameter of 52.3 mm fits well.
+
+Filming the LEDs "in action" is very hard, maybe you can get an idea:
+
+![animated LED ring animation](pictures/NeoPixelRing-lightning.gif)
 
 
 # License

--- a/spacemouse-keys/config_sample.h
+++ b/spacemouse-keys/config_sample.h
@@ -30,6 +30,7 @@ Debug Modes:
 4:  Output translation and rotation values. Approximately -350 to +350 depending on the parameter.
 5:  Output debug 4 and 5 side by side for direct cause and effect reference.
 6:  Report velocity and keys after possible kill-key feature
+61: Report velocity and keys after Switch or ExclusiveMode
 7:  Report the frequency of the loop() -> how often is the loop() called in one second?
 8:  Report the bits and bytes send as button codes
 9:  Report details about the encoder wheel, if ROTARY_AXIS > 0

--- a/spacemouse-keys/config_sample.h
+++ b/spacemouse-keys/config_sample.h
@@ -409,3 +409,11 @@ This little extra noise is called "jiggling" and ensures that a value declared a
 // #define ADV_HID_JIGGLE
 
 
+/* Exclusive mode
+=================
+Exclusive mode only permit to send translation OR rotation, but never both at the same time.
+This can solve issues with classic joysticks where you get unwanted translation or rotation at the same time.
+
+it choose to send the one with the biggest absolute value.
+*/
+#define EXCLUSIVEMODE

--- a/spacemouse-keys/config_sample.h
+++ b/spacemouse-keys/config_sample.h
@@ -30,7 +30,7 @@ Debug Modes:
 4:  Output translation and rotation values. Approximately -350 to +350 depending on the parameter.
 5:  Output debug 4 and 5 side by side for direct cause and effect reference.
 6:  Report velocity and keys after possible kill-key feature
-61: Report velocity and keys after Switch or ExclusiveMode
+61: Report velocity and keys after kill-switch or ExclusiveMode
 7:  Report the frequency of the loop() -> how often is the loop() called in one second?
 8:  Report the bits and bytes send as button codes
 9:  Report details about the encoder wheel, if ROTARY_AXIS > 0
@@ -243,6 +243,15 @@ How many keys reported? */
 // The keys from KEYLIST are assigned to buttons here:
 #define BUTTONLIST { SM_FIT, SM_T, SM_R, SM_RCW }
 
+/* Exclusive mode
+=================
+Exclusive mode only permit to send translation OR rotation, but never both at the same time.
+This can solve issues with classic joysticks where you get unwanted translation or rotation at the same time.
+
+it choose to send the one with the biggest absolute value.
+*/
+#define EXCLUSIVEMODE
+
 /* Kill-Key Feature
 --------------------
 Are there buttons to set the translation or rotation to zero?
@@ -408,13 +417,3 @@ This little extra noise is called "jiggling" and ensures that a value declared a
 
 // Add Jiggling to the value reported, if the following symbol is defined:
 // #define ADV_HID_JIGGLE
-
-
-/* Exclusive mode
-=================
-Exclusive mode only permit to send translation OR rotation, but never both at the same time.
-This can solve issues with classic joysticks where you get unwanted translation or rotation at the same time.
-
-it choose to send the one with the biggest absolute value.
-*/
-#define EXCLUSIVEMODE

--- a/spacemouse-keys/kinematics.cpp
+++ b/spacemouse-keys/kinematics.cpp
@@ -122,7 +122,7 @@ void calculateKinematic(int *centered, int16_t *velocity)
         }
     }
     else
-    {                                                                               // pulling the knob upwards is much heavier... smaller factor
+    {                                                                                                // pulling the knob upwards is much heavier... smaller factor
         velocity[TRANSZ] = constrain(velocity[TRANSZ] / ((float)POS_TRANSZ_SENSITIVITY), -350, 350); // no modifier function, just constrain linear!
     }
 
@@ -197,4 +197,25 @@ void switchYZ(int16_t *velocity)
     tmp = velocity[ROTY];
     velocity[ROTY] = velocity[ROTZ];
     velocity[ROTZ] = tmp;
+}
+
+/// @brief Check if translation or rotation is dominant and set the other values to zero to allow exclusively rotation or translation
+// to avoid issues with classics joysticks
+/// @param velocity
+void exclusiveMode(int16_t *velocity)
+{
+    uint16_t totalRot = abs(velocity[ROTX]) + abs(velocity[ROTY]) + abs(velocity[ROTZ]);
+    uint16_t totalTrans = abs(velocity[TRANSX]) + abs(velocity[TRANSY]) + abs(velocity[TRANSZ]);
+    if (totalRot > totalTrans)
+    {
+        velocity[TRANSX] = 0;
+        velocity[TRANSY] = 0;
+        velocity[TRANSZ] = 0;
+    }
+    else
+    {
+        velocity[ROTX] = 0;
+        velocity[ROTY] = 0;
+        velocity[ROTZ] = 0;
+    }
 }

--- a/spacemouse-keys/kinematics.cpp
+++ b/spacemouse-keys/kinematics.cpp
@@ -201,7 +201,7 @@ void switchYZ(int16_t *velocity)
 
 /// @brief Check if translation or rotation is dominant and set the other values to zero to allow exclusively rotation or translation
 // to avoid issues with classics joysticks
-/// @param velocity
+/// @param velocity pointer to velocity array
 void exclusiveMode(int16_t *velocity)
 {
     uint16_t totalRot = abs(velocity[ROTX]) + abs(velocity[ROTY]) + abs(velocity[ROTZ]);

--- a/spacemouse-keys/kinematics.h
+++ b/spacemouse-keys/kinematics.h
@@ -11,6 +11,7 @@ void calculateKinematic(int* centered, int16_t* velocity);
 
 void switchXY(int16_t *velocity);
 void switchYZ(int16_t *velocity);
+void exclusiveMode(int16_t *velocity);
 
 // The following constants are here for more readable access to the arrays. You don't need to change this values!
 // Axes in centered or rawValues array

--- a/spacemouse-keys/spacemouse-keys.ino
+++ b/spacemouse-keys/spacemouse-keys.ino
@@ -202,23 +202,17 @@ void loop()
 #endif
 
 #ifdef EXCLUSIVEMODE
-  // exclusif mode
+  // exclusive mode
   // rotation OR translation, but never both at the same time
   // to avoid issues with classics joysticks
-
-  if ((abs(velocity[ROTX]) > abs(velocity[TRANSX])) or  (abs(velocity[ROTX]) > abs(velocity[TRANSY])) or  (abs(velocity[ROTX]) > abs(velocity[TRANSZ])) or
-      (abs(velocity[ROTY]) > abs(velocity[TRANSX])) or  (abs(velocity[ROTY]) > abs(velocity[TRANSY])) or  (abs(velocity[ROTY]) > abs(velocity[TRANSZ])) or
-      (abs(velocity[ROTZ]) > abs(velocity[TRANSX])) or  (abs(velocity[ROTZ]) > abs(velocity[TRANSY])) or  (abs(velocity[ROTZ]) > abs(velocity[TRANSZ])) )
-  {
-    velocity[TRANSX] = 0 ;
-    velocity[TRANSY] = 0 ;
-    velocity[TRANSZ] = 0 ;
-  } else {
-    velocity[ROTX] = 0 ;
-    velocity[ROTY] = 0 ;
-    velocity[ROTZ] = 0 ;
-  }
+  exclusiveMode(velocity);
 #endif
+
+  // report velocity and keys after Switch or ExclusiveMode
+  if (debug == 61)
+  {
+    debugOutput4(velocity, keyOut);
+  }
 
   // get the values to the USB HID driver to send if necessary
   SpaceMouseHID.send_command(velocity[ROTX], velocity[ROTY], velocity[ROTZ], velocity[TRANSX], velocity[TRANSY], velocity[TRANSZ], keyState, debug);

--- a/spacemouse-keys/spacemouse-keys.ino
+++ b/spacemouse-keys/spacemouse-keys.ino
@@ -201,6 +201,25 @@ void loop()
   switchYZ(velocity);
 #endif
 
+#ifdef EXCLUSIVEMODE
+  // exclusif mode
+  // rotation OR translation, but never both at the same time
+  // to avoid issues with classics joysticks
+
+  if ((abs(velocity[ROTX]) > abs(velocity[TRANSX])) or  (abs(velocity[ROTX]) > abs(velocity[TRANSY])) or  (abs(velocity[ROTX]) > abs(velocity[TRANSZ])) or
+      (abs(velocity[ROTY]) > abs(velocity[TRANSX])) or  (abs(velocity[ROTY]) > abs(velocity[TRANSY])) or  (abs(velocity[ROTY]) > abs(velocity[TRANSZ])) or
+      (abs(velocity[ROTZ]) > abs(velocity[TRANSX])) or  (abs(velocity[ROTZ]) > abs(velocity[TRANSY])) or  (abs(velocity[ROTZ]) > abs(velocity[TRANSZ])) )
+  {
+    velocity[TRANSX] = 0 ;
+    velocity[TRANSY] = 0 ;
+    velocity[TRANSZ] = 0 ;
+  } else {
+    velocity[ROTX] = 0 ;
+    velocity[ROTY] = 0 ;
+    velocity[ROTZ] = 0 ;
+  }
+#endif
+
   // get the values to the USB HID driver to send if necessary
   SpaceMouseHID.send_command(velocity[ROTX], velocity[ROTY], velocity[ROTZ], velocity[TRANSX], velocity[TRANSY], velocity[TRANSZ], keyState, debug);
 


### PR DESCRIPTION
This PR is just to add the ability to configure a exclusive mode where spacemouse will send exclusively rotation or translation.

This is mainly to solve unwanted rotation or translation sent at the same time.