### PR TITLE
Rotary as hid keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ config*.h
 !config_sample.h
 
 
+README_tmp.html

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# New Update April 2025: Rotary Keys
+# New Update April 2025: 
+## Link to support for Onshape under linux
+For linux users: Check out the simple python wrapper by mamatt to use Onshape from ubuntu: https://github.com/mamatt/space2onshape
+
+## Rotary Keys
 
 When you are using the mouse with an encoder wheel, there is a new feature: Rotary Keys. 
 
@@ -143,6 +147,8 @@ If all goes well, the 3DConnexion software will show a SpaceMouse Pro wireless w
 
 ## spacenav for linux users
 Checkout https://wiki.freecad.org/3Dconnexion_input_devices and https://github.com/FreeSpacenav/spacenavd.
+
+Onshape is not jet supported by spacenav direclty but there is a simple wrapper here: https://github.com/mamatt/space2onshape 
 
 # Software Main Idea
 1. The software reads the eight ADC values of the four joy sticks

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# New Update April 2025: Rotary Keys
+
+When you are using the mouse with an encoder wheel, there is a new feature: Rotary Keys. 
+
+When you enable this feature in the config, see _ROTARY_KEYS_, the encoder is not treated as an axis or movement but repeatedly triggers a button. This can be done to e.g. hit the volume+ button while turning the wheel clockwise.
+
+Note: We are still using the emulated USB HID protocoll for the CAD mouse. Therefore, you need to define the pressed button in the config.h and than configure some actions on your PC driver. We are not emulating a standard keyboard. 
+
+See [#68](https://github.com/AndunHH/spacemouse/issues/68) for more details.
+
 # New Update March 2025: Exclusive Mode
 
 When the exclusive mode is activated in the config.h only the major movement is transmitted. 
@@ -28,20 +38,30 @@ To see all features in place, like the buttons and the encoder, check out the di
 ![ErgonoMouse MK XX - 6DOF Controller Knob & Joystick with Wheel, Buttons & Keys](pictures/ergonomouse.webp)
 
 ## Features of the 6 DOF mouse
+
+### General Features
+
 - Source code for an Arduino Pro Micro to read four joysticks and calculate the kinematics
 - Emulation of the USB identification and the HID interface to behave like an original space mouse
 - Advanced USB settings for linux users: Implemented jiggling or declaring the HID reports as relative or absolute values
 - Semi-Automatic calibration methods to find the correct pin outs and measurement ranges
 - Debug outputs can be requested over the serial interface during run time, see [config_sample.h](spacemouse-keys/config_sample.h#L36) 
-- Over ten keys may be reported to the PC via USB and may be evaluated by the original driver software
-- "Kill-Keys" may disable translation or rotation directly in the mouse
 - Exclusive-Mode: Transmit either translation or rotation and set the other one to zero, depending on what the main motion is.
+
+### Buttons 
+- Over ten keys may be reported to the PC via USB and may be evaluated by the original driver software
+- Kill-Keys: Press one of two buttons to disable translation or rotation directly in the mouse and transmit just the other one.
+
+### Encoder / Wheel
 - An encoder wheel can be used to replace one axis and allow e.g. zooming
 - Check out the [config_sample.h](spacemouse-keys/config_sample.h) for more informations about configurable elements and extensive debug outputs
+
+### LEDs
+
 - LED can be enabled by the PC driver
 - Support for a [LED ring](#support-for-neopixel-led-ring), as supported by the FastLED library
 
-Wanted features:
+### Wanted features, not jet there:
 - Reverse Direction and Speed options in 3dConnexion Software is not working, because our spacemouse is not accepting this settings.
 
 Purchasing the [electronics](#electronics) and [printing some parts](#printed-parts) is not scope of this repository. We start with the software. Feel free to read a build report in the Wiki: [Building an Ergonomouse](https://github.com/AndunHH/spacemouse/wiki/Ergonomouse-Build)
@@ -197,6 +217,8 @@ The basis is fdmakara's four joystick movement logic, with jfedor/BennyBWalker's
 11. Moved the Deadzone detection into the inital ADC conversion and calculate every value everytime and use the modifier for better seperation between the access, By Andun_HH.
 12. Added two additional buttons integrated into the knob to kill either translation or rotation at will and prevent unintended movements, by JoseLuisGZA and AndunHH.
 13. Added Encoder to use with a wheel on top of the main knob an simulate pulls on any of the axis (main use is simulating zoom like the mouse wheel), by [JoseLuizGZA](https://github.com/JoseLuisGZA/ErgonoMouse/) and rewritten by AndunHH.
+
+Please check the release history for more recent history...
 
 # Specific features
 

--- a/spacemouse-keys/config_sample.h
+++ b/spacemouse-keys/config_sample.h
@@ -240,8 +240,8 @@ How many keys reported? Classical + ROTARY_KEYS in total.
 #define SM_CTRL     25 // Key "CTRL"
 #define SM_ROT      26 // Key "Rotate" 
 
-// BUTTONLIST must have as many elements as NUMHIDKEYS
-// The keys from KEYLIST are assigned to buttons here:
+// BUTTONLIST must have at least as many elements as NUMHIDKEYS
+// The keys from KEYLIST or ROTARY_KEYS are assigned to buttons here:
 #define BUTTONLIST { SM_FIT, SM_T, SM_R, SM_RCW }
 
 /* Exclusive mode
@@ -346,16 +346,18 @@ Recommended strength = 200
 */
 #define SIMSTRENGTH 200
 
-/* ROTARY_KEY
+/* ROTARY_KEYS
 =============
 Use the encoder and emulate a key stroke by turning the encoder.
 */
 #define ROTARY_KEYS 0
 // which key from the BUTTONLIST shall be emulated?
-// direction 1
+// First direction  (0 = first element from BUTTONLIST, 1 = second element, etc.)
 #define ROTARY_KEY_IDX_A 2
 // counter direction
 #define ROTARY_KEY_IDX_B 3
+// duration of simulated key
+#define ROTARY_KEY_STRENGTH 19
 
 
 /* LED support 

--- a/spacemouse-keys/config_sample.h
+++ b/spacemouse-keys/config_sample.h
@@ -33,7 +33,7 @@ Debug Modes:
 61: Report velocity and keys after kill-switch or ExclusiveMode
 7:  Report the frequency of the loop() -> how often is the loop() called in one second?
 8:  Report the bits and bytes send as button codes
-9:  Report details about the encoder wheel, if ROTARY_AXIS > 0
+9:  Report details about the encoder wheel, if ROTARY_AXIS > 0 or ROTARY_KEYS>0
 */
 #define STARTDEBUG 0  // Can also be set over the serial interface, while the program is running!
 
@@ -205,20 +205,21 @@ The suggestion in the comments for "3Dc" are often needed on windows PCs with 3d
 /* Key Support 
 ===============
 If you attached keys to your Spacemouse, configure them here. 
-You can use the keys to report them via USB HID to the PC or as kill-keys (described below).
+You can use the keys to report them via USB HID to the PC (either classically pressed or emulated with an encoder) or as kill-keys (described below).
 
-How many keys are there in total? (0=no keys, feature disabled)
+How many classic keys are there in total? (0=no keys, feature disabled)
 */
 #define NUMKEYS 0
 
-// Define the pins for the keys on the Arduino
+// Define the PINS for the classic keys on the Arduino
 // The first pins from KEYLIST may be reported via HID
 #define KEYLIST \
   { 15, 14, 16, 10 }
 
 /* Report KEYS over USB HID to the PC
  ----------------------------------
-How many keys reported? */
+How many keys reported? Classical + ROTARY_KEYS in total.
+*/
 #define NUMHIDKEYS 0
 
 // In order to define which key is assigned to which button, the following list must be entered in the BUTTONLIST below
@@ -344,6 +345,18 @@ Recommended range: 0 - 350
 Recommended strength = 200
 */
 #define SIMSTRENGTH 200
+
+/* ROTARY_KEY
+=============
+Use the encoder and emulate a key stroke by turning the encoder.
+*/
+#define ROTARY_KEYS 0
+// which key from the BUTTONLIST shall be emulated?
+// direction 1
+#define ROTARY_KEY_IDX_A 2
+// counter direction
+#define ROTARY_KEY_IDX_B 3
+
 
 /* LED support 
 ===============

--- a/spacemouse-keys/encoderWheel.cpp
+++ b/spacemouse-keys/encoderWheel.cpp
@@ -87,7 +87,7 @@ void calcEncoderAsKey(uint8_t keyState[NUMKEYS], int debug)
     if (newEncoderValue != previousEncoderValue)
     {
         // If the position changed, add this to delta. As long as delta != 0, report the key as pressed
-        delta = (newEncoderValue - previousEncoderValue)*30 + delta;
+        delta = (newEncoderValue - previousEncoderValue)*ROTARY_KEY_STRENGTH + delta;
         previousEncoderValue = newEncoderValue;
         
         if (debug == 9)

--- a/spacemouse-keys/encoderWheel.cpp
+++ b/spacemouse-keys/encoderWheel.cpp
@@ -59,10 +59,11 @@ void calcEncoderWheel(int16_t *velocity, int debug)
         velocity[ROTARY_AXIS - 1] = velocity[ROTARY_AXIS - 1] + simpull;
     }
     else
-    { 
+    {
         // fading has ended
         simpull = 0;
     }
+
     if (debug == 9)
     {
         // create debug output
@@ -72,6 +73,39 @@ void calcEncoderWheel(int16_t *velocity, int debug)
         Serial.print(factor);
         Serial.print(", simpull: ");
         Serial.println(simpull);
+    }
+}
+
+/// @brief Read out the encoder and treat as keystroke
+/// @param keyState overwrite some keys with encoder movement
+/// @param debug Generate a debug output if debug=9
+
+void calcEncoderAsKey(uint8_t keyState[NUMKEYS], int debug)
+{
+    // read encoder
+    newEncoderValue = myEncoder.read();
+    if (newEncoderValue != previousEncoderValue)
+    {
+        // dirty hack: If the position changed (ignore direction), add this to delta. As long as delta > 0, report the key as pressed
+        delta = abs((newEncoderValue - previousEncoderValue))*30 + delta;
+        previousEncoderValue = newEncoderValue;
+        
+        if (debug == 9)
+        {
+            // create debug output
+            Serial.print("Enc Val: ");
+            Serial.println(newEncoderValue);
+        }
+    }
+
+    if (delta > 0) {
+        // press the button for some small time
+        keyState[0] = 1;
+        delta--;
+    }
+    else
+    {
+        keyState[0] = 0;
     }
 }
 #endif // whole file is only implemented #if ROTARY_AXIS > 0

--- a/spacemouse-keys/encoderWheel.cpp
+++ b/spacemouse-keys/encoderWheel.cpp
@@ -4,12 +4,12 @@
  * Therefore, we calculate a filtered derivative from the encoder position and
  * replace the desired velocity from the original space mouse.
  *
- * Based on the idea by JoseLuisGZA, rewritten by Andun HH
+ * Based on the idea by JoseLuisGZA, rewritten by AndunHH
  */
 
 #include <Arduino.h>
 #include "config.h"
-#if ROTARY_AXIS > 0
+#if ROTARY_AXIS > 0 or ROTARY_KEYS > 0
 #include "encoderWheel.h"
 
 // Include Encoder library by Paul Stoffregen
@@ -87,7 +87,7 @@ void calcEncoderAsKey(uint8_t keyState[NUMKEYS], int debug)
     if (newEncoderValue != previousEncoderValue)
     {
         // dirty hack: If the position changed (ignore direction), add this to delta. As long as delta > 0, report the key as pressed
-        delta = abs((newEncoderValue - previousEncoderValue))*30 + delta;
+        delta = (newEncoderValue - previousEncoderValue)*30 + delta;
         previousEncoderValue = newEncoderValue;
         
         if (debug == 9)
@@ -100,12 +100,18 @@ void calcEncoderAsKey(uint8_t keyState[NUMKEYS], int debug)
 
     if (delta > 0) {
         // press the button for some small time
-        keyState[0] = 1;
+        keyState[ROTARY_KEY_IDX_A] = 1;
         delta--;
+    }
+    else if (delta < 0) {
+        // press the button for some small time
+        keyState[ROTARY_KEY_IDX_B] = 1;
+        delta++;
     }
     else
     {
-        keyState[0] = 0;
+        keyState[ROTARY_KEY_IDX_A] = 0;
+        keyState[ROTARY_KEY_IDX_B] = 0;
     }
 }
 #endif // whole file is only implemented #if ROTARY_AXIS > 0

--- a/spacemouse-keys/encoderWheel.cpp
+++ b/spacemouse-keys/encoderWheel.cpp
@@ -86,7 +86,7 @@ void calcEncoderAsKey(uint8_t keyState[NUMKEYS], int debug)
     newEncoderValue = myEncoder.read();
     if (newEncoderValue != previousEncoderValue)
     {
-        // dirty hack: If the position changed (ignore direction), add this to delta. As long as delta > 0, report the key as pressed
+        // If the position changed, add this to delta. As long as delta != 0, report the key as pressed
         delta = (newEncoderValue - previousEncoderValue)*30 + delta;
         previousEncoderValue = newEncoderValue;
         
@@ -114,4 +114,4 @@ void calcEncoderAsKey(uint8_t keyState[NUMKEYS], int debug)
         keyState[ROTARY_KEY_IDX_B] = 0;
     }
 }
-#endif // whole file is only implemented #if ROTARY_AXIS > 0
+#endif // whole file is only implemented #if ROTARY_AXIS > 0 or ROTARY_KEYS > 0

--- a/spacemouse-keys/encoderWheel.h
+++ b/spacemouse-keys/encoderWheel.h
@@ -2,3 +2,4 @@
 
 void initEncoderWheel();
 void calcEncoderWheel(int16_t* velocity, int debug);
+void calcEncoderAsKey(uint8_t keyState[NUMKEYS], int debug);

--- a/spacemouse-keys/spacemouse-keys.ino
+++ b/spacemouse-keys/spacemouse-keys.ino
@@ -21,7 +21,7 @@
 // header for HID emulation of the spacemouse
 #include "SpaceMouseHID.h"
 
-#if ROTARY_AXIS > 0
+#if ROTARY_AXIS > 0 or ROTARY_KEYS > 0
 // if an encoder wheel is used
 #include "encoderWheel.h"
 #endif
@@ -77,7 +77,7 @@ void setup()
   // during setup() we are not interested in the debug output: debugFlag = false
   busyZeroing(centerPoints, 500, false);
 
-#if ROTARY_AXIS > 0
+#if ROTARY_AXIS > 0 or ROTARY_KEYS > 0
   initEncoderWheel();
 #endif
 #ifdef LEDpin
@@ -154,7 +154,7 @@ void loop()
 
   calculateKinematic(centered, velocity);
 
-#if (ROTARY_AXIS > 0) && ROTARY_AXIS < 7
+#if ROTARY_AXIS > 0
   // If an encoder wheel is used, calculate the velocity of the wheel and replace one of the former calculated velocities
   calcEncoderWheel(velocity, debug);
 #endif
@@ -163,7 +163,7 @@ void loop()
   evalKeys(keyVals, keyOut, keyState);
 #endif
 
-#if ROTARY_AXIS == 7
+#if ROTARY_KEYS > 0 
  // The encoder wheel shall be treated as a key
   calcEncoderAsKey(keyState, debug);
 #endif

--- a/spacemouse-keys/spacemouse-keys.ino
+++ b/spacemouse-keys/spacemouse-keys.ino
@@ -49,8 +49,9 @@ int centered[8];
 // store raw value of the keys, without debouncing
 int keyVals[NUMKEYS];
 
-// final value of the keys, after debouncing
+// key event, after debouncing. It is 1 only for a single sample
 uint8_t keyOut[NUMKEYS];
+// state of the key, which stays 1 as long as the key is pressed
 uint8_t keyState[NUMKEYS];
 
 // Resulting calculated velocities / movements
@@ -153,13 +154,18 @@ void loop()
 
   calculateKinematic(centered, velocity);
 
-#if ROTARY_AXIS > 0
+#if (ROTARY_AXIS > 0) && ROTARY_AXIS < 7
   // If an encoder wheel is used, calculate the velocity of the wheel and replace one of the former calculated velocities
   calcEncoderWheel(velocity, debug);
 #endif
 
 #if NUMKEYS > 0
   evalKeys(keyVals, keyOut, keyState);
+#endif
+
+#if ROTARY_AXIS == 7
+ // The encoder wheel shall be treated as a key
+  calcEncoderAsKey(keyState, debug);
 #endif
 
   if (debug == 4)


### PR DESCRIPTION
This pull request will emulate keys as suggest in #68 

- [x] Adapt readme.md: describe this new feature

When you use ROTARY_KEYS 1 you can define two keys from BUTTONLIST which are "pressed", when the encoder is turned. (You can make the BUTTONLIST longer, then the classical pins for KEYLIST to adress to special keys for the encoder)

ROTARY_KEY_IDX_A is for one direction and ROTARY_KEY_IDX_B for the reverse direction. In this variables you indicate the index in BUTTONLIST.

@chrisns please gives this cleaned up approach with both directions a try.