### PR TITLE
Integrated PCB Hall Effect Spacemouse into the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ config*.h
 .idea
 
 //this file should be included:
-!config_sample.h
+!config_sample*.h
 
 
 README_tmp.html

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ config*.h
 
 
 README_tmp.html
+README.pdf

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Check-out the [Release Page](https://github.com/AndunHH/spacemouse/releases) for
 
 # Ongoing work on the master-branch
 ## Hall effect sensors + Springs
-@JarnoBoks merged the source code by @ChromeBee [space mouse with linear hall effect sensors](https://www.printables.com/model/940040-cad-mouse-spacemouse-using-hall-effect-sensors) resp. [the github repo](https://github.com/ChromeBee/Hall-Effect-Sensor-CAD-Mouse-Spacemouse) with this repository to integrate the hall effect sensor space mouse approach. 
+@JarnoBoks merged the source code by @ChromeBee [space mouse with linear hall effect sensors](https://www.printables.com/model/940040-cad-mouse-spacemouse-using-hall-effect-sensors) resp. [the github repo](https://github.com/ChromeBee/Hall-Effect-Sensor-CAD-Mouse-Spacemouse) with this repository to integrate the hall effect sensor space mouse approach. The code is especially using the [PCB by Michael Roth](https://www.printables.com/model/1063960-cad-mouse-spacemouse-using-hall-effect-sensors-w-p).
 
 In this mouse the joysticks are replaced by springs, magnets and linear hall effect sensors to avoid the mechanical limits of the joystick approach.
 

--- a/README.md
+++ b/README.md
@@ -1,42 +1,29 @@
-# New Update April 2025: 
-## Link to support for Onshape under linux
-For linux users: Check out the simple python wrapper by mamatt to use Onshape from ubuntu: https://github.com/mamatt/space2onshape
+# Newest Stable Release
+Check-out the [Release Page](https://github.com/AndunHH/spacemouse/releases) for the newest releases and updates!
 
-## Rotary Keys
+- 0.8: Proper USB Interface with LED control
+- 0.9: Exclusive mode and [LED ring support](#neopixel-led-ring)
+- April 2025: [Version 1.0](https://github.com/AndunHH/spacemouse/releases/tag/v1.0.0): [Rotary encoder triggers keys](#rotary-keys)
 
-When you are using the mouse with an encoder wheel, there is a new feature: Rotary Keys. 
+# Ongoing work on the master-branch
+## Hall effect sensors + Springs
+@JarnoBoks merged the source code by @ChromeBee [space mouse with linear hall effect sensors](https://www.printables.com/model/940040-cad-mouse-spacemouse-using-hall-effect-sensors) resp. [the github repo](https://github.com/ChromeBee/Hall-Effect-Sensor-CAD-Mouse-Spacemouse) with this repository to integrate the hall effect sensor space mouse approach. 
 
-When you enable this feature in the config, see _ROTARY_KEYS_, the encoder is not treated as an axis or movement but repeatedly triggers a button. This can be done to e.g. hit the volume+ button while turning the wheel clockwise.
+In this mouse the joysticks are replaced by springs, magnets and linear hall effect sensors to avoid the mechanical limits of the joystick approach.
 
-Note: We are still using the emulated USB HID protocoll for the CAD mouse. Therefore, you need to define the pressed button in the config.h and than configure some actions on your PC driver. We are not emulating a standard keyboard. 
-
-See [#68](https://github.com/AndunHH/spacemouse/issues/68) for more details.
-
-# New Update March 2025: Exclusive Mode
-
-When the exclusive mode is activated in the config.h only the major movement is transmitted. 
-That means, that the mouse detects, if you want to translate or rotate.
-
-When the biggest input is a translation: All rotations are set to zero.
-
-When the biggest input is a rotation: All translations are set to zero.
-
-This function is the sister of the kill-key feature, where you press a key to decide wether only translations or rotations are transmitted.
-
-Thanks to @mamatt in #73 for this suggestion!
+To read the eight linear hall effect sensors instead of the joysticks, use the `HALLEFFECT` definition in the config.h. @JarnoBoks provided a complete example: [config_sample_hall_effect.h](spacemouse-keys/config_sample_hall_effect.h) and proceed with the calibration as described in the config file.
 
 # Open Source six degree of freedom (6 DOF) mouse with keys, encoder and more
-Repository for a 3D mouse, which emulates a 3Dconnexion "Space Mouse Pro wireless". (This repository is NOT affiliated with 3Dconnexion. We just reverse-engineered the USB protocoll.)
+Repository for a 3D mouse, which emulates a 3Dconnexion "Space Mouse Pro wireless". 
+(This repository is NOT affiliated with 3Dconnexion. We just reverse-engineered the USB protocol.)
 
 ![Overview over the 6 DOF mouse](pictures/Ergonomouse-Advertiser.png)
 
-It is based on four joysticks with additional keys or an encoder.
+It is based on four joysticks with additional keys OR an encoder or on springs and linear hall effect sensors, as seen here by [John Crombies space mouse with linear hall effect sensors](https://www.printables.com/model/940040-cad-mouse-spacemouse-using-hall-effect-sensors)
 
 ![overview](pictures/overview.jpg)
 
-This repository for the source code is based on the work by [TeachingTech](https://www.printables.com/de/model/864950-open-source-spacemouse-space-mushroom-remix) and many other contributors, as seen in [the history](#History). 
-
-To see all features in place, like the buttons and the encoder, check out the different versions by Jose L. González, like the 
+To see many features in place, like the buttons and the encoder, check out the different versions by Jose L. González, like the 
  [ErgonoMouse MK XX - 6DOF Controller Knob & Joystick with Wheel, Buttons & Keys](https://www.printables.com/de/model/973725-ergonomouse-mk-xx-free-version-6dof-controller-kno): 
 
 ![ErgonoMouse MK XX - 6DOF Controller Knob & Joystick with Wheel, Buttons & Keys](pictures/ergonomouse.webp)
@@ -45,12 +32,13 @@ To see all features in place, like the buttons and the encoder, check out the di
 
 ### General Features
 
-- Source code for an Arduino Pro Micro to read four joysticks and calculate the kinematics
+- Source code for an Arduino Pro Micro
+- Read eight analog inputs and calculate the kinematics (either based on four joysticks or eight linear hall effect sensors)
 - Emulation of the USB identification and the HID interface to behave like an original space mouse
 - Advanced USB settings for linux users: Implemented jiggling or declaring the HID reports as relative or absolute values
 - Semi-Automatic calibration methods to find the correct pin outs and measurement ranges
 - Debug outputs can be requested over the serial interface during run time, see [config_sample.h](spacemouse-keys/config_sample.h#L36) 
-- Exclusive-Mode: Transmit either translation or rotation and set the other one to zero, depending on what the main motion is.
+- [Exclusive-Mode](#exclusive-mode): Transmit either translation or rotation and set the other one to zero, depending on what the main motion is.
 
 ### Buttons 
 - Over ten keys may be reported to the PC via USB and may be evaluated by the original driver software
@@ -58,27 +46,30 @@ To see all features in place, like the buttons and the encoder, check out the di
 
 ### Encoder / Wheel
 - An encoder wheel can be used to replace one axis and allow e.g. zooming
-- Check out the [config_sample.h](spacemouse-keys/config_sample.h) for more informations about configurable elements and extensive debug outputs
+- Check out the [config_sample.h](spacemouse-keys/config_sample.h) for more information about configurable elements and extensive debug outputs
+- The encoder can simulate consecutively pressed buttons (e.g. volume +), see [Rotary Keys](#rotary-keys)
 
 ### LEDs
 
 - LED can be enabled by the PC driver
-- Support for a [LED ring](#support-for-neopixel-led-ring), as supported by the FastLED library
+- Support for a [LED ring](#neopixel-led-ring), as supported by the FastLED library. E.g. a neopixel
 
 ### Wanted features, not jet there:
 - Reverse Direction and Speed options in 3dConnexion Software is not working, because our spacemouse is not accepting this settings.
+- Saving settings in the eeprom (instead of compiling newly found parameters).
 
-Purchasing the [electronics](#electronics) and [printing some parts](#printed-parts) is not scope of this repository. We start with the software. Feel free to read a build report in the Wiki: [Building an Ergonomouse](https://github.com/AndunHH/spacemouse/wiki/Ergonomouse-Build)
+Purchasing the [electronics](#electronics) and [printing some parts](#printed-parts) is not scope of this repository. We start with the software. Feel free to read some build reports:
+- In the Wiki: [Building an Ergonomouse](https://github.com/AndunHH/spacemouse/wiki/Ergonomouse-Build) based on four joysticks
  
 ## Macro-Pad for CAD users
-The original 3Dconnexion windows driver is very elegant to detect which programm you are running and offering custom actions for the keys on a space mouse. You can utilize this behavior and build a space mouse with keys, just without the central part, the space mouse itself. You are left with keys, that you can assign to actions for your CAD programm. This comes handy, if your original spacemouse doesn't have enough keys. In this case your PC will see an additional mouse where only the keystrokes are send and evaluated.
+The original 3Dconnexion windows driver is very elegant to detect which program you are running and offering custom actions for the keys on a space mouse. You can utilize this behavior and build a space mouse with keys, just without the central part, the space mouse itself. You are left with keys, that you can assign to actions for your CAD program. This comes handy, if your original spacemouse doesn't have enough keys. In this case your PC will see an additional mouse where only the keystrokes are send and evaluated.
 
 # Getting Started with PlatformIO
 You can use PlatformIO to flash the board with this fast steps.
 PlatformIO is easier than ArduinoIDE, because you don't need to change the board.txt files there.
 
 1. Install [PlatformIO](https://platformio.org/).
-2. Clone this repo into a folder (hint for windows: network locations are not recommended)
+2. [Download or clone this github repository](#cloning-the-github-repo) (hint for windows: network locations are not recommended)
 3. Copy and rename `spacemouse-keys/config_sample.h` to `spacemouse-keys/config.h` and change the values to whatever suits.
 4. Open PlatformIO / vscode and open the newly created folder.
 5. Click on the upload arrow in the IDE in the status bar or run `pio run -t upload`.
@@ -96,7 +87,7 @@ PlatformIO is easier than ArduinoIDE, because you don't need to change the board
 7. Done!
    
 ## Custom board to emulate the space mouse
-The boards.txt file needs an additional board definition, which tells the microprocessor to report the USB identifiers correctly and emulate the 3dconnexion space-mouse. Please follow the detailled instructions on the [wiki page about custom board definition](https://github.com/AndunHH/spacemouse/wiki/Creating-a-custom-board-for-Arduino-IDE). 
+The boards.txt file needs an additional board definition, which tells the microprocessor to report the USB identifiers correctly and emulate the 3dconnexion space-mouse. Please follow the detailed instructions on the [wiki page about custom board definition](https://github.com/AndunHH/spacemouse/wiki/Creating-a-custom-board-for-Arduino-IDE). 
 
 ## Cloning the github repo
 Clone the github repo to your computer: Scroll-Up to the green "<> Code" Button and select, if you wish to clone or just download the code.
@@ -120,7 +111,7 @@ Troubleshooting for uploading is explained in detail here:
 
 
 # Calibrate your hardware
-After compiling and uploading the programm to your hardware, you can connect via the serial monitor. In the upper line, you can send the desired debug mode to the board and observe the output. "-1" stops the debug output.
+After compiling and uploading the program to your hardware, you can connect via the serial monitor. In the upper line, you can send the desired debug mode to the board and observe the output. "-1" stops the debug output.
 
 Read and follow the instructions throughout the config.h file and write down your results. Recompile after every step.
 
@@ -134,25 +125,26 @@ All debug outputs are described at the top of your config_sample.h.
 4. Adjust sensitivity
 5. Choose modifier function:
 
-Choose a modifier function with the help of the following picture. Note, that the Squared, Squared Tan and Cubed Tan function act like a deadzone filter, because small inputs are resulting in nearly zero output, which may reduced unwanted movements. 
+Choose a modifier function with the help of the following picture. Note, that the Squared, Squared Tan and Cubed Tan function act like a dead one filter, because small inputs are resulting in nearly zero output, which may reduce unwanted movements. 
 Also note, that some of those functions are already at their maximum output (and therefore limited), before the input reaches 350.
+
 ![picture illustrating the different modifier functions](pictures/modifierFunctions.svg)
 
 
 # Use the 6 DOF mouse
 ## Download the 3dconnexion driver on windows and mac
-You will also need to download and install the [3DConnexion software](https://3dconnexion.com/us/drivers-application/3dxware-10/)
+Download and install the [3DConnexion software](https://3dconnexion.com/us/drivers-application/3dxware-10/)
 
 If all goes well, the 3DConnexion software will show a SpaceMouse Pro wireless when the Arduino is connected.
 
 ## spacenav for linux users
 Checkout https://wiki.freecad.org/3Dconnexion_input_devices and https://github.com/FreeSpacenav/spacenavd.
 
-Onshape is not jet supported by spacenav direclty but there is a simple wrapper here: https://github.com/mamatt/space2onshape 
+Onshape is not jet supported by spacenav directly but there is a simple wrapper here: https://github.com/mamatt/space2onshape 
 
 # Software Main Idea
-1. The software reads the eight ADC values of the four joy sticks
-2. During start-up the zero-position of the joystick is measured and subtracted from the adc-value. -> The values now range from e.g. -500 to +500
+1. The software reads the eight ADC values
+2. During start-up the zero-position of the space mouse is measured and subtracted from the adc-value. -> The values now range from e.g. -500 to +500
 3. A dead zone in the middle is applied to avoid small noisy movements. (E.g. every value between +/- 3 is fixed to zero)
 4. The movement of the joysticks is mapped from the original about ca. +/- 500 digits to exactly +/- 350. (Therefore the real min and max values will be calibrated) Now all further calculations can be done with this normalized values between +/-350.
 5. We calculate the translation and rotation based on this.
@@ -163,12 +155,14 @@ Onshape is not jet supported by spacenav direclty but there is a simple wrapper 
 # Printed parts
 There are many parts and remixes available. A very good starting point is the Part [Open source SpaceMouse - Space Mushroom remix](https://www.printables.com/de/model/864950-open-source-spacemouse-space-mushroom-remix) by Teaching Tech. Check out the many remixes, especially if you want to use other joysticks modules!
 
-Here are some of the remixes or additions that are used with this software:
+Here are some of the remixes or additions that may be used with this software:
 
 * [ErgonoMouse MK XX - 6DOF Controller Knob & Joystick with Wheel, Buttons & Keys](https://www.printables.com/de/model/973725-ergonomouse-mk-xx-free-version-6dof-controller-kno) by Jose L. González (Free and premium version available)
 * [Lid with mounting for 4 MX Switch adapter](https://www.printables.com/de/model/883967-tt-spacemouse-v2-lid-with-mounting-for-4-mx-switch) by LivingTheDream
 * [SpaceMouse Mini - Slim profile, with easier assembly and various improvements - v3](https://www.printables.com/de/model/908684-spacemouse-mini-slim-profile-with-easier-assembly) by Doug Joseph
 * [Hall Effect Joysticks For the Space Mouse](https://www.printables.com/de/model/918029-hall-effect-joysticks-for-the-space-mouse) by Kempy
+* [CAD mouse / Spacemouse using Hall Effect Sensors](https://www.printables.com/model/940040-cad-mouse-spacemouse-using-hall-effect-sensors) by JohnCrombie
+* [Hall-Effect-Sensor-CAD-Mouse-Spacemouse](https://github.com/ChromeBee/Hall-Effect-Sensor-CAD-Mouse-Spacemouse/tree/main) with TPU springs by JohnCrombie.
 
 
 # Electronics and pin assignment
@@ -181,8 +175,8 @@ Maybe your joystick axis are named X and Y in an other orientation. That doesn't
 
 ![analog](pictures/pins-axis.png)
 
-The calculation in this programm results in X, Y and Z calculated as shown in the middle of the picture.
-If this doesn't suit your programm change it by using the INVX or SWITCHYZ afterwards.
+The calculation in this program results in X, Y and Z calculated as shown in the middle of the picture.
+If this doesn't suit your program change it by using the INVX or SWITCHYZ afterwards.
 
 ## Kinematics
 With the axis defined as shown in the picture above, the calculations for translation and rotation are as follows:
@@ -194,41 +188,10 @@ ROTX = -CX + AX
 ROTY = -BX + DX
 ROTZ = AY + BY + CY + DY
 ```
-# See also
-
-Here are some other projects with regard to space mice. The arrow indicates what is emulated. 
-
-* [This repository itself](https://github.com/AndunHH/spacemouse) -> space mouse
-* [DIY SpaceMouse Profiles](https://github.com/raulpetru/DIY_SpaceMouse_Profiles) -> User interface to tune e.g. sensitivity of the mouse
-* [A 6 degrees of freedom mouse for CAD programs using cheap linear Hall Effect sensors for position measurement](https://github.com/ChromeBee/Hall-Effect-Sensor-CAD-Mouse-Spacemouse) -> space mouse
-* [DIY Spacemouse for Fusion 360](https://github.com/sb-ocr/diy-spacemouse) -> Mouse and Keyboard
-* [spacemouse with an esp32](https://github.com/horvatkm/space_mouse_esp32s2) -> work in progress -> space mouse pro
-* [Space Fox](https://github.com/pepijndevos/spacefox) -> Joystick based on potentiometers
-* [Orbion The OpenSource 3D Space Mouse](https://github.com/FaqT0tum/Orbion_3D_Space_Mouse) -> Mouse and Keyboard
-
-
-# History
-This code is the combination of multiple works by others. This list summarizes what happened before this github repository was started:
-1. Original code for the Space Mushroom by Shiura on Thingiverse: https://www.thingiverse.com/thing:5739462
-2. The next two from the comments on the instructables page: https://www.instructables.com/Space-Mushroom-Full-6-DOFs-Controller-for-CAD-Appl/
-3. and the comments of Thingiverse: https://www.thingiverse.com/thing:5739462/comments
-4. Code to emulate a 3DConnexion Space Mouse by jfedor: https://pastebin.com/gQxUrScV
-5. This code was then remixed by BennyBWalker to include the above two sketches: https://pastebin.com/erhTgRBH
-6. Four joystick remix code by fdmakara: https://www.thingiverse.com/thing:5817728
-7. [Teaching Techs work](https://www.printables.com/de/model/864950-open-source-spacemouse-space-mushroom-remix) involves mixing all of these: 
-The basis is fdmakara's four joystick movement logic, with jfedor/BennyBWalker's HID SpaceMouse emulation. The four joystick logic sketch was setup for the joystick library instead of HID, so elements of this were omitted where not needed.  The outputs were jumbled no matter how Teaching Tech plugged them in, so Teaching Tech spent a lot of time adding debugging code to track exactly what was happening. On top of this, Teching Tech has added more control of speed/direction and comments/links to informative resources to try and explain what is happening in each phase.
-8. Code to include meassured min and max values for each Joystick by Daniel_1284580 (In Software Version V1 and newer)
-9. Improved code to make it more userfriendly by Daniel_1284580 (In Software Version V2 and newer)
-10. Improved Code, improved comments and added written tutorials in comments, by [LivingTheDream](https://www.printables.com/de/model/883967-tt-spacemouse-v2-lid-with-mounting-for-4-mx-switch/files) Implemented new algorithm "modifier function" for better motioncontrol by Daniel_1284580 (In Software Version V3)
-11. Moved the Deadzone detection into the inital ADC conversion and calculate every value everytime and use the modifier for better seperation between the access, By Andun_HH.
-12. Added two additional buttons integrated into the knob to kill either translation or rotation at will and prevent unintended movements, by JoseLuisGZA and AndunHH.
-13. Added Encoder to use with a wheel on top of the main knob an simulate pulls on any of the axis (main use is simulating zoom like the mouse wheel), by [JoseLuizGZA](https://github.com/JoseLuisGZA/ErgonoMouse/) and rewritten by AndunHH.
-
-Please check the release history for more recent history...
-
 # Specific features
+This section gives a deeper look into features that came into the mouse during time with the releases. 
 
-## Support for neopixel led ring
+## Neopixel led ring
 
 December 2024 Update: Support for LED rings like a neopixel! 
 
@@ -240,6 +203,41 @@ Filming the LEDs "in action" is very hard, maybe you can get an idea:
 
 ![animated LED ring animation](pictures/NeoPixelRing-lightning.gif)
 
+## Exclusive Mode
+
+
+When the exclusive mode is activated in the config.h only the major movement is transmitted. 
+That means, that the mouse detects, if you want to translate or rotate.
+
+When the biggest input is a translation: All rotations are set to zero.
+
+When the biggest input is a rotation: All translations are set to zero.
+
+This function is the sister of the kill-key feature, where you press a key to decide wether only translations or rotations are transmitted.
+
+Thanks to @mamatt in #73 for this suggestion which were released in Version 0.9.
+
+## Rotary Keys
+
+When you are using the mouse with an encoder wheel, there is a new feature: Rotary Keys. 
+
+When you enable this feature in the config, see _ROTARY_KEYS_, the encoder is not treated as an axis or movement but repeatedly triggers a button. This can be done to e.g. hit the volume+ button while turning the wheel clockwise.
+
+Note: We are still using the emulated USB HID protocoll for the CAD mouse. Therefore, you need to define the pressed button in the config.h and than configure some actions on your PC driver. We are not emulating a standard keyboard. 
+
+See [#68](https://github.com/AndunHH/spacemouse/issues/68) for more details.
+
+# See also
+
+Here are some other projects with regard to space mice. The arrow indicates what is emulated. 
+
+* [This repository itself](https://github.com/AndunHH/spacemouse) -> space mouse
+* [DIY SpaceMouse Profiles](https://github.com/raulpetru/DIY_SpaceMouse_Profiles) -> User interface to tune e.g. sensitivity of the mouse
+* [A 6 degrees of freedom mouse for CAD programs using cheap linear Hall Effect sensors for position measurement](https://github.com/ChromeBee/Hall-Effect-Sensor-CAD-Mouse-Spacemouse) -> space mouse
+* [DIY Spacemouse for Fusion 360](https://github.com/sb-ocr/diy-spacemouse) -> Mouse and Keyboard
+* [Space Fox](https://github.com/pepijndevos/spacefox) -> Joystick based on potentiometers
+* [Orbion The OpenSource 3D Space Mouse](https://github.com/FaqT0tum/Orbion_3D_Space_Mouse) -> Mouse and Keyboard
+* [Space mouse with linear hall effect sensors](https://www.printables.com/model/940040-cad-mouse-spacemouse-using-hall-effect-sensors) resp. [the github repo](https://github.com/ChromeBee/Hall-Effect-Sensor-CAD-Mouse-Spacemouse) -> space mouse with hall effect sensors
 
 # License
 Because TeachingTech published his source code on Printables under this license, it also applies here:
@@ -254,3 +252,23 @@ This work is licensed under a
 [cc-by-nc-sa]: http://creativecommons.org/licenses/by-nc-sa/4.0/
 [cc-by-nc-sa-image]: https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png
 [cc-by-nc-sa-shield]: https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg
+
+
+# History
+This code is the combination of multiple works by others. This list summarizes what happened before this github repository was started:
+1. Original code for the Space Mushroom by Shiura on Thingiverse: https://www.thingiverse.com/thing:5739462
+2. The next two from the comments on the instructables page: https://www.instructables.com/Space-Mushroom-Full-6-DOFs-Controller-for-CAD-Appl/
+3. and the comments of Thingiverse: https://www.thingiverse.com/thing:5739462/comments
+4. Code to emulate a 3DConnexion Space Mouse by jfedor: https://pastebin.com/gQxUrScV
+5. This code was then remixed by BennyBWalker to include the above two sketches: https://pastebin.com/erhTgRBH
+6. Four joystick remix code by fdmakara: https://www.thingiverse.com/thing:5817728
+7. [Teaching Techs work](https://www.printables.com/de/model/864950-open-source-spacemouse-space-mushroom-remix) involves mixing all of these: 
+The basis is fdmakara four joystick movement logic, with jfedor / BennyBWalker's HID SpaceMouse emulation. The four joystick logic sketch was setup for the joystick library instead of HID, so elements of this were omitted where not needed. The outputs were jumbled no matter how TeachingTech plugged them in, so TeachingTech spent a lot of time adding debugging code to track exactly what was happening. On top of this, TeachingTech has added more control of speed / direction and comments / links to informative resources to try and explain what is happening in each phase.
+8. Code to include measured min and max values for each Joystick by Daniel_1284580 (In Software Version V1 and newer)
+9. Improved code to make it more user friendly by Daniel_1284580 (In Software Version V2 and newer)
+10. Improved Code, improved comments and added written tutorials in comments, by [LivingTheDream](https://www.printables.com/de/model/883967-tt-spacemouse-v2-lid-with-mounting-for-4-mx-switch/files) Implemented new algorithm "modifier function" for better motion control by Daniel_1284580 (In Software Version V3)
+11. Moved the dead zone detection into the initial ADC conversion and calculate every value every time and use the modifier for better separation between the access, By Andun_HH.
+12. Added two additional buttons integrated into the knob to kill either translation or rotation at will and prevent unintended movements, by JoseLuisGZA and AndunHH.
+13. Added Encoder to use with a wheel on top of the main knob an simulate pulls on any of the axis (main use is simulating zoom like the mouse wheel), by [JoseLuizGZA](https://github.com/JoseLuisGZA/ErgonoMouse/) and rewritten by AndunHH.
+
+Please check the [release history](https://github.com/AndunHH/spacemouse/releases) for more recent history...

--- a/spacemouse-keys/calibration.cpp
+++ b/spacemouse-keys/calibration.cpp
@@ -108,7 +108,7 @@ unsigned long startTime; // Start time for the measurement
 #define MINMAX_MINWARNING 250
 #define MINMAX_MAXWARNING 250
 #else
-// The Hall effect sensors aren't centered arount zero, due to the nature of the hardware.
+// The Hall effect sensors aren't centered around zero, due to the nature of the hardware.
 // In my version of the Spacemouse, the values vary between -425 and 285, the centerpoint is thus around -70
 // The MIN and MAX warning levels have to be shifted accordingly.
 #define MINMAX_MINWARNING (100 - centerPoint)
@@ -289,11 +289,11 @@ bool busyZeroing(int *centerPoints, uint16_t numIterations, boolean debugFlag)
     #define CENTERPOINTWARNINGMIN 384
     #define CENTERPOINTWARNINGMAX 640
 #else
-        // The centerpoint off the Hall effect mouse is not in the center of the ADC range, due to the hardware nature.
+        // The centerpoint of the Hall effect mouse is not in the center of the ADC range, due to the hardware nature.
         // According to the height of the base plate, the centerpoint is shifted up or downwards.
         // a centerpoint below or above those values will be warned (512 +/- 128)
-#define CENTERPOINTWARNINGMIN (720 - 128)
-#define CENTERPOINTWARNINGMAX (720 + 128)
+    #define CENTERPOINTWARNINGMIN (720 - 128)
+    #define CENTERPOINTWARNINGMAX (720 + 128)
 #endif
 
     if (deadZone[i] > DEADZONEWARNING || centerPoints[i] < CENTERPOINTWARNINGMIN || centerPoints[i] > CENTERPOINTWARNINGMAX)

--- a/spacemouse-keys/config_sample_hall_effect.h
+++ b/spacemouse-keys/config_sample_hall_effect.h
@@ -41,9 +41,6 @@ Debug Modes:
 */
 #define STARTDEBUG 0 // Can also be set over the serial interface, while the program is running!
 
-// Generate a debug line only every DEBUGDELAY ms
-#define DEBUGDELAY 200
-
 // Hardware uses HallEffect sensors instead of joystick sensors
 #define HALLEFFECT
 
@@ -368,6 +365,7 @@ Recommended strength = 200
 /* ROTARY_KEYS
 =============
 Use the encoder and emulate a key stroke by turning the encoder.
+ROTARY_KEYS 1 = enabled, 0 = disabled
 */
 #define ROTARY_KEYS 0
 // which key from the BUTTONLIST shall be emulated?
@@ -377,6 +375,7 @@ Use the encoder and emulate a key stroke by turning the encoder.
 #define ROTARY_KEY_IDX_B 3
 // duration of simulated key
 #define ROTARY_KEY_STRENGTH 19
+
 
 /* LED support
 ===============
@@ -411,6 +410,20 @@ The connected LED is not just a stupid LED, but an intelligent one, like a neopi
 
 // how often shall the LEDs be updated
 #define LEDUPDATERATE_MS 150
+
+
+/* Advanced debug output settings
+=================================
+The following settings allow customization of debug output behavior */
+
+// Generate a debug line only every DEBUGDELAY ms 
+#define DEBUGDELAY 100
+
+// The standard behavior "\r" for the debug output is, that the values are always written into the same line to get a clean output. Easy readable for the human.
+#define DEBUG_LINE_END "\r"
+// If you need to report some debug outputs to trace errors, you can change the debug output to "\r\n" to get a newline with each debug output. (old behavior)
+//define DEBUG_LINE_END "\r\n"
+
 
 /* Advanced USB HID settings
 ============================

--- a/spacemouse-keys/config_sample_hall_effect.h
+++ b/spacemouse-keys/config_sample_hall_effect.h
@@ -1,0 +1,454 @@
+#ifndef CONFIG_h
+#define CONFIG_h
+
+/* The user specific settings, like pin mappings or special configuration variables and sensitivities are stored in config.h.
+   This file is meant for the << HALL-EFFECT SPACEMOUSE >>
+   Please adjust your settings and save it as --> config.h <-- !
+*/
+
+/* Calibration instructions
+============================
+Follow this file from top to bottom to calibrate your space mouse.
+You can find some pictures for the calibration process here:
+https://github.com/AndunHH/spacemouse/wiki/Ergonomouse-Build#calibration
+
+Debugging Instructions
+=========================
+To activate one of the following debugging modes, you can either:
+- Change STARTDEBUG here in the code and compile again or
+- Compile and upload your program. Change to the serial monitor and type the number and hit enter to select the debug mode.
+
+Debug Modes:
+------------
+-1: Debugging off. Set to this once everything is working.
+0:  Nothing...
+
+1:  Output raw joystick values. 0-1023 raw ADC 10-bit values
+11: Calibrate / Zero the Spacemouse and get a dead-zone suggestion (This is also done on every startup in the setup())
+
+2:  Output centered joystick values. Values should be approximately -500 to +500, jitter around 0 at idle.
+20: semi-automatic min-max calibration. (Replug/reset the mouse, to enable the semi-automatic calibration for a second time.)
+
+3:  Output centered joystick values. Filtered for deadzone. Approximately -350 to +350, locked to zero at idle, modified with a function.
+
+4:  Output translation and rotation values. Approximately -350 to +350 depending on the parameter.
+5:  Output debug 4 and 5 side by side for direct cause and effect reference.
+6:  Report velocity and keys after possible kill-key feature
+61: Report velocity and keys after kill-switch or ExclusiveMode
+7:  Report the frequency of the loop() -> how often is the loop() called in one second?
+8:  Report the bits and bytes send as button codes
+9:  Report details about the encoder wheel, if ROTARY_AXIS > 0 or ROTARY_KEYS>0
+*/
+#define STARTDEBUG 0 // Can also be set over the serial interface, while the program is running!
+
+// Generate a debug line only every DEBUGDELAY ms
+#define DEBUGDELAY 200
+
+// Hardware uses HallEffect sensors instead of joystick sensors
+#define HALLEFFECT
+
+/* First Calibration: Hall effect sensors pin assignment
+==============================================
+Default assembly when looking from above on top of the space mouse
+ *
+ *    back(USB)     resulting axis (not from the single sensors)
+ *
+ *      7   6              Y+
+ *        |                .
+ *   8    |    3           .
+ *     ---+---        X-...Z+...X+
+ *   9    |    2           .
+ *        |                .
+ *      0   1              Y-
+ *
+
+Each sensor is affected by the position of the magnet. If the magnet moves closer to the sensor the output values should decrease.
+If you have mounted the magnets upside-down, the values will be inverted.
+
+1. Try to write down the each HES sensor with the corresponding pin number you chose. If you use the PCB version, the pins are shown
+   on the silk screen.
+2. Compile the script, type 1 into the serial interface and hit enter to enable debug output 1.
+3. With the spacemouse in front of you (ie. USB connection at the backside ie. @ north), move the knob from south to north and observe the debug output:
+  3.a) HES0 & HES1 both increase when moving the knob north (magnets further away) and decrease when moving the knob south -> Everything is correct.
+  3.b) HES0 & HES1 both decrease when moving the knob south (magnets closer by) -> Everything is correct.
+  3.c) The sensorpair acts in the opposite direction (ie. increasing when the magnets get closer by ). You probably have mixed up the poles of the magnets.
+       Invert the sensorpair in the INVERTLIST.
+  3.c) Another output is showing movement: Swap the pins in the PINLIST. This shouldn't happen when the PCB is used. Debugging is rather difficult when
+       the spacemouse is assembled, due to the fact that all sensors act on the same movement.
+
+4. Continue with the other sensor pairs. Moving the magnet closer to the sensor should decrease the value.
+
+5. Optimally when not moving the knob, all sensors should output approximately the same value. You can adjuist the values a little bit
+   by adjusting the height of the sensor plate using the spacernuts.
+
+5. Repeat this with every axis and every sensor pair until you have a valid PINLIST and maybe an INVERTLIST
+*/
+
+// HES0, HES1, HES2, HES3, HES6, HES7, HES8, HES9
+#define PINLIST \
+    {A0, A1, A2, A3, A6, A7, A8, A9}
+// Check the correct wiring with the debug output=1
+
+// Set to 1 to invert one hall sensor.
+// Values should decrease when the magnet is nearing the sensor, but if the magnet is placed with the poles reversed, you can
+// invert the value. Usually the inversion should be configured by HES-pair (ie. 0 & 1, 2 & 3, 6 & 7, 8 & 9)
+#define INVERTLIST \
+    {0, 0, 0, 0, 0, 0, 0, 0}
+// HES0, HES1, HES2, HES3, HES6, HES7, HES8, HES9
+
+/* Second calibration: Tune Deadzone
+====================================
+Deadzone to filter out unintended movements. Increase if the mouse has small movements when it should be idle or the mouse is too sensitive to subtle movements.
+
+Semi-automatic: Set debug = 11. Don't touch the mouse and observe the automatic output.
+Manual:         Set debug = 2.  Don't touch the mouse but observe the values. They should be nearly to zero.
+                                Every value around zero which is noise or should be neglected afterwards is in the following deadzone.
+*/
+#define DEADZONE 15 // Recommended to have this as small as possible to allow full range of motion.
+
+/* Third calibration: Getting MIN and MAX values
+================================================
+Can be done manual (debug = 2) or semi-automatic (debug = 20)
+
+Semi-automatic (debug=20)
+------------------------
+1. Compile the sketch and upload it.
+2. Go to the serial monitor type 20 and hit enter. -> debug is set to 20.
+3. Move the Spacemouse around for 15s to get a min and max value.
+// TODO - minMax are different for the HES sensors
+4. Verify, that the minimums are around -400 to -520 and the maxVals around +400 to +520.
+   (repeat or check again, if you have too small values!)
+5. Copy the output from the console into your config.h below.
+
+Manual min/max calibration (debug = 2)
+--------------------------------------
+Recommended calibration procedure for min/max ADC levels
+1. Compile the sketch and upload it. Go to the serial monitor type 2 and hit enter. -> debug is set to 2.
+2. Get a piece of paper and write the following chart:
+ Chart:
+ maxVals      | minVals
+-------------------------------
+ HES0+:         | HES0-:
+ HES1+:         | HES1-:
+ HES2+:         | HES2-:
+ HES3+:         | HES3-:
+ HES6+:         | HES6-:
+ HES7+:         | HES7-:
+ HES8+:         | HES8-:
+ HES9+:         | HES9-:
+
+3. (a) Start out with HES0 (positive Values)
+   (b) Start moving the your Spacemouse and try increasing the Value of HES0 till you can't get a higher value out of it.
+   (c) this is your positive maximum value for HES0 so write it down for HES0
+4. Do the same for HES1,HES2,HES3,....HES9
+5. Do the same for your negative Values to populate the minVals
+6. Write all the positive Values starting from the top into the Array maxValues
+7. Write all the negative Values starting from the top into the Array minValues
+8. You finished calibrating.
+
+Insert measured Values like this: {HES0, HES1, HES2, HES3, HES6, HES7, HES8, HES9}
+*/
+#define MINVALS {-400, -400, -400, -400, -400, -400, -400, -400}
+#define MAXVALS {+175, +175, +175, +175, +175, +175, +175, +175}
+
+/* Fourth calibration: Sensitivity
+==================================
+Use debug mode 4 or use for example your CAD program to verify changes.
+
+The sensitivity values are used in a division, thus
+  - Use a fraction to make the axis MORE sensitive. F.e. 0.5 makes the axis twice as sensitive.
+  - Use a value larger than 1 to make it LESS sensitive. F.e. 5 makes the axis five times less sensitive.
+
+Recommended calibration procedure for sensitivity
+-------------------------------------------------
+1. Make sure modFunc is on level 0, see below. Upload the sketch. Then open serial monitor, type 4 for and hit enter.
+   You will see Values TX, TY, TZ, RX, RY, RZ, the configured keys and the current status of the sensitivity parameters.
+2. Start moving your Spacemouse. You will notice values changing.
+3. Starting with TX try increasing this value as much as possible by moving your Spacemouse around. If you get around 350 thats great.
+   If not change TRANSX_SENSITIVITY. Repeat until it is around 350 for maximum motion.
+4. Repeat steps 3 for TY, TZ, RX, RY, RZ
+5. Verification: Move the Joystick in funny ways. All you should get for either TX,TX,TZ,RX,RY,RZ should be approximately between -350 to 350.
+6. You have finished sensitivity calibration. You can now test your Spacemouse with your favorite program (e.g. Cad software, Slicer)
+7. Aftermath: You notice the movements are hard to control. Try using Modification Functions [Suggestion: ModFunc level 3]
+*/
+
+#define TRANSX_SENSITIVITY 0.80
+#define TRANSY_SENSITIVITY 0.99
+#define POS_TRANSZ_SENSITIVITY 2.5
+#define NEG_TRANSZ_SENSITIVITY 1.5
+#define GATE_NEG_TRANSZ 15 // gate value, which negative z movements will be ignored (like an additional deadzone for -z).
+#define GATE_ROTX 15       // Value under which rotX values will be forced to zero
+#define GATE_ROTY 15       // Value under which roty values will be forced to zero
+#define GATE_ROTZ 15       // Value under which rotz values will be forced to zero
+
+#define ROTX_SENSITIVITY 1.2
+#define ROTY_SENSITIVITY 1.2
+#define ROTZ_SENSITIVITY 0.90
+
+/* Fifth calibration: Modifier Function
+=======================================
+Modify resulting behaviour of Spacemouse outputs to suppress small movements around zero and enforce big movements even more.
+
+Check the README.md for more details and a plot of the different functions.
+(This function is applied on the resulting velocities and not on the direct input from the joysticks)
+
+This should be at level 0 when starting the calibration!
+0: linear y = x [Standard behaviour: No modification]
+1: squared function y = x^2*sign(x) [altered squared function working in positive and negative direction]
+2: tangent function: y = tan(x) [Results in a linear curve near zero but increases the more you are away from zero]
+3: squared tangent function: y = tan(x^2*sign(X)) [Results in a flatter curve near zero but increases a lot the more you are away from zero]
+4: cubed tangent function: y = tan(x^3) [Results in a very flat curve near zero but increases drastically the more you are away from zero]
+
+Recommendation after tuning: MODFUNC 3
+*/
+#define MODFUNC 0 // Used as default value as long as the data hasn't been saved in the EEPROM
+
+/* Sixth Calibration: Direction
+===============================
+Modify the direction of translation/rotation depending on the CAD program you are using on your PC.
+This should be done, when you are done with the pin assignment!
+
+If all defines are set to 0 the resulting X, Y and Z axis correspond to the pictures shown in the README.md.
+The suggestion in the comments for "3Dc" are often needed on windows PCs with 3dconnexion driver to get expected behavior.
+*/
+#define INVX 1  // pan left/right  // 3Dc: 0
+#define INVY 1  // pan up/down     // 3Dc: 1
+#define INVZ 1  // zoom in/out     // 3Dc: 1
+#define INVRX 1 // Rotate around X axis (tilt front/back)  // 3Dc: 0
+#define INVRY 1 // Rotate around Y axis (tilt left/right)  // 3Dc: 1
+#define INVRZ 1 // Rotate around Z axis (twist left/right) // 3Dc: 1
+
+// Switch Zoom direction with Up/Down Movement
+#define SWITCHYZ 0 // change to 1 to switch Y and Z axis
+
+/* Key Support
+===============
+If you attached keys to your Spacemouse, configure them here.
+You can use the keys to report them via USB HID to the PC (either classically pressed or emulated with an encoder) or as kill-keys (described below).
+
+How many classic keys are there in total? (0=no keys, feature disabled)
+*/
+#define NUMKEYS 3 // 0
+
+// Define the PINS for the classic keys on the Arduino
+// The first pins from KEYLIST may be reported via HID
+#define KEYLIST \
+    {0, 1, 2}
+
+/* Report KEYS over USB HID to the PC
+ ----------------------------------
+How many keys reported? Classical + ROTARY_KEYS in total.
+*/
+#define NUMHIDKEYS 3 // 0
+
+// In order to define which key is assigned to which button, the following list must be entered in the BUTTONLIST below
+
+#define SM_MENU 0  // Key "Menu"
+#define SM_FIT 1   // Key "Fit"
+#define SM_T 2     // Key "Top"
+#define SM_R 4     // Key "Right"
+#define SM_F 5     // Key "Front"
+#define SM_RCW 8   // Key "Roll 90°CW"
+#define SM_1 12    // Key "1"
+#define SM_2 13    // Key "2"
+#define SM_3 14    // Key "3"
+#define SM_4 15    // Key "4"
+#define SM_ESC 22  // Key "ESC"
+#define SM_ALT 23  // Key "ALT"
+#define SM_SHFT 24 // Key "SHIFT"
+#define SM_CTRL 25 // Key "CTRL"
+#define SM_ROT 26  // Key "Rotate"
+
+// BUTTONLIST must have at least as many elements as NUMHIDKEYS
+// The keys from KEYLIST or ROTARY_KEYS are assigned to buttons here:
+#define BUTTONLIST {SM_T, SM_R, SM_F}
+
+/* Exclusive mode
+=================
+Exclusive mode only permit to send translation OR rotation, but never both at the same time.
+This can solve issues with classic joysticks where you get unwanted translation or rotation at the same time.
+
+it choose to send the one with the biggest absolute value.
+*/
+#define EXCLUSIVEMODE
+
+/* Kill-Key Feature
+--------------------
+Are there buttons to set the translation or rotation to zero?
+How many kill keys are there? (disabled: 0; enabled: 2)
+*/
+#define NUMKILLKEYS 0
+// usually you take the last two buttons from KEYLIST as kill-keys
+// Index of the kill key for rotation
+#define KILLROT 2
+// Index of the kill key for translation
+#define KILLTRANS 3
+// Note: Technically you can report the kill-keys via HID as "usual" buttons, but that doesn't make much sense...
+
+/*  Example for NO KEYS
+ *  There are zero keys in total:  NUMKEYS 0
+ *  KEYLIST { }
+ *  NUMHIDKEYS 0
+ *  BUTTONLIST { }
+ *  NUMKILLKEYS 0
+ *  KILLROT and KILLTRANS don't matter... KILLROT 0 and KILLTRANS 0
+ */
+
+/*  Example for three usual buttons and no kill-keys
+ *  There are three keys in total:  NUMKEYS 3
+ *  The keys which shall be reported to the pc are connected to pin 15, 14 and 16
+ *  KEYLIST {15, 14, 16}
+ *  Therefore, the first three pins from the KEYLIST apply for the HID: NUMHIDKEYS 3
+ *  Those three Buttons shall be "FIT", "T" and "R": BUTTONLIST {SM_FIT, SM_T, SM_R}
+ *  No keys for kill-keys NUMKILLKEYS 0
+ *  KILLROT and KILLTRANS don't matter... KILLROT 0 and KILLTRANS 0
+ */
+
+/*
+ *  Example for two usual buttons and two kill-keys:
+ *  There are four keys in total:  NUMKEYS 4
+ *  The keys which shall be reported to the pc are connected to pin 15 and 14
+ *  The keys which shall be used to kill translation or rotation are connected to pin 16 and 10
+ *  KEYLIST {15, 14, 16, 10}
+ *  Therefore, the first two pins from the KEYLIST apply for the HID: NUMHIDKEYS 2
+ *  Those two Buttons shall be "3", "4": BUTTONLIST {SM_3, SM_4}
+ *  Two keys are used as kill-keys: NUMKILLKEYS 2
+ *  The first kill key has the third position in the KEYLIST and due to zero-based counting third-1 => KILLROT 2
+ *  The second kill key has the last position in the KEYLIST with index 3 -> KILLTRANS 3
+ */
+
+// Some simple tests for the definition of the keys
+#if (NUMKILLKEYS > NUMKEYS)
+#error "Number of Kill Keys can not be larger than total number of keys"
+#endif
+#if (NUMKILLKEYS > 0 && ((KILLROT > NUMKEYS) || (KILLTRANS > NUMKEYS)))
+#error "Index of killkeys must be smaller than the total number of keys"
+#endif
+
+// time in ms which is needed to allow a new button press
+#define DEBOUNCE_KEYS_MS 200
+
+/* Encoder Wheel
+================
+You can attach an encoder to the mouse, which acts as an input device for one movement.
+Needs the encoder library by Paul Stoffregen (https://www.pjrc.com/teensy/td_libs_Encoder.html).
+*/
+
+// Define the encoder pins
+#define ENCODER_CLK 2
+#define ENCODER_DT 3
+// swap those two pins to change direction of encoder
+
+/*
+Axis to replace with encoder
+0. None -> disable this feature completely
+1. transX
+2. transY (zoom in "Forward / Backward" Zoom Direction configuration, see SWITCHYZ)
+3. transZ (simulates zoom in "Up / Down" Zoom Direction configuration , see SWITCHYZ)
+4. rotX
+5. rotY
+6. rotZ
+(Those are the positions in the velocity array +1, as defined in kinematics.h)
+*/
+#define ROTARY_AXIS 0
+
+/* To calculate a velocity from the encoder position, the output is faded over so many loop() iterations, as defined in #ECHOES
+Small number = short duration of zooming <-> Big Number = longer duration of zooming
+Compare this number with the update frequency of the script, reported by debug=7: If ECHOES = frequency: the zoom is faded for 1 second.
+*/
+#define ECHOES 200
+
+/* Strength of the simulated pull
+Recommended range: 0 - 350
+  Reason for max=350: The HID Interface reports logical max as +350, see hidInterface.h
+Recommended strength = 200
+*/
+#define SIMSTRENGTH 200
+
+/* ROTARY_KEYS
+=============
+Use the encoder and emulate a key stroke by turning the encoder.
+*/
+#define ROTARY_KEYS 0
+// which key from the BUTTONLIST shall be emulated?
+// First direction  (0 = first element from BUTTONLIST, 1 = second element, etc.)
+#define ROTARY_KEY_IDX_A 2
+// counter direction
+#define ROTARY_KEY_IDX_B 3
+// duration of simulated key
+#define ROTARY_KEY_STRENGTH 19
+
+/* LED support
+===============
+You can attach:
+a) a simple LED to the mouse. LED shall be connected to 5V and the controller port.
+b) a fancy LED strip, like the nanopixel. Check the FASTLED library for supported chips / led strips.
+
+Which pin shall be used as LED? This pin is used either as a digital pin (a) or as the data pin (b).
+Change from "//define" to "#define" to activate the LED feature.
+*/
+// #define LEDpin 5
+
+/* Simple LED
+-------------
+// If you have connected a single LED to the controller port and GND, invert it by uncommenting this #define
+*/
+// #define LEDinvert
+
+/* LED strip with data pin
+---------------------------
+The connected LED is not just a stupid LED, but an intelligent one, like a neopixel controlled by FASTLED library. If set, the LEDRING gives the number of LEDs on the ring.
+*/
+
+// #define LEDRING 24
+//  The LEDpin is used as a data pin
+
+// The LEDs light up, if a certain movement is reached:
+#define VelocityDeadzoneForLED 15
+
+// About how many LEDs must the ring by turned to align?
+#define LEDclockOffset 0
+
+// how often shall the LEDs be updated
+#define LEDUPDATERATE_MS 150
+
+/* Advanced USB HID settings
+============================
+The following settings are advanced and don't need to changed for normal windows users.
+*/
+
+// Definition, how many bits are used in the HID report to encode the keys
+#define HIDMAXBUTTONS 32 // must be multiple of 8!
+
+/* ADV_HID_REL and ADV_HID_JIGGLE change how the values are reported over HID protocol, see hidInterface.cpp and .h
+
+For windows users: DON'T CHANGE / DON'T ENABLE THIS, if you don't understand what it does.
+
+For linux / spacenavd user: Suggestions to enable #define ADV_HID_JIGGLE
+
+Translation and rotation values are either declared as absolute or relative values in the hid descriptor in hidInterface.h.
+
+Relative declaration (may be activated by ADV_HID_REL)
+-------------------------------------------------------
+With linux and spacenavd: If the space mouse didn't return to absolutely zero in one axis this axis will still report movement, when another direction is pushed, because only the changed values are emitted as events by the linux kernel.
+
+Despite that, values events are emitted with every report send, even if they didn't changed.
+
+Absolute declaration (default)
+------------------------------
+Every value is always reporting the absolute position.
+This means, in contrast to relative, an axis that is left alone is reported again as zero.
+On the other hand, events are only emitted, if at least some value changes.
+This is not always the case, when the space mouse is held still at a non-zero position.
+Solution: Jiggling (may be activated by ADV_HID_JIGGLE)
+Every non-zero value is reported as it is and +1 in the next report, repeating with +0 in the next iteration and +1 in the next...
+This little extra noise is called "jiggling" and ensures that a value declared as absolute is resent with every report, because is not equal to the last value.
+*/
+
+// Switch declaration of values to relative, if the following symbol is defined:
+// #define ADV_HID_REL
+
+// Add Jiggling to the value reported, if the following symbol is defined:
+// #define ADV_HID_JIGGLE
+
+#endif // CONFIG_h

--- a/spacemouse-keys/kinematics.h
+++ b/spacemouse-keys/kinematics.h
@@ -24,6 +24,18 @@ void exclusiveMode(int16_t *velocity);
 #define DX 6
 #define DY 7
 
+// SECTION HALLEFFECT
+// When using HallE sensors in centered or rawValues array
+#define HES0 0
+#define HES1 1
+#define HES2 2
+#define HES3 3
+#define HES6 4
+#define HES7 5
+#define HES8 6
+#define HES9 7
+// !SECTION HALLEFFECT
+
 // Define position in velocity array.
 #define TRANSX 0
 #define TRANSY 1


### PR DESCRIPTION
Based on the sketch that John Crombie wrote.

The original sketch is good, but this repository has much more configurable calibration settings. 
In this PR I have incorporated the specifics for the PCB Hall Effect Spacemouse. By setting a preprocessor directive in config.h (#define HALLEFFECT), the Hall Effect code comes into effect. 

I've added a config_sample_hall_effect.h
This is a copy of config_sample.h, but rewritten into the Hall Effect version. Including the change of default sensitivity values. 

The changes are minimal, but there is some 'whitespace' that changed due to my formatter I'm afraid. Tried to minimalize, but couldn't find the settings this repo uses for formatting unfortunately. 